### PR TITLE
feat: add ORM layer with SQLAlchemy

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,3 @@
+[alembic]
+script_location = alembic
+sqlalchemy.url = sqlite:///bot.db

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,37 @@
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+
+from bot.db import Base, DATABASE_URL
+
+config = context.config
+fileConfig(config.config_file_name)
+config.set_main_option("sqlalchemy.url", DATABASE_URL)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(url=url, target_metadata=target_metadata, literal_binds=True)
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/versions/0001_initial.py
+++ b/alembic/versions/0001_initial.py
@@ -1,0 +1,87 @@
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0001_initial"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "guilds",
+        sa.Column("id", sa.BigInteger(), primary_key=True),
+        sa.Column("name", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+    )
+    op.create_table(
+        "channels",
+        sa.Column("id", sa.BigInteger(), primary_key=True),
+        sa.Column("guild_id", sa.BigInteger(), sa.ForeignKey("guilds.id"), nullable=True),
+        sa.Column("name", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column("settings_json", sa.JSON(), nullable=True),
+    )
+    op.create_table(
+        "subscriptions",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("channel_id", sa.BigInteger(), sa.ForeignKey("channels.id"), nullable=False),
+        sa.Column("type", sa.String(), nullable=False),
+        sa.Column("target_id", sa.String(), nullable=False),
+        sa.Column("target_kind", sa.String(), nullable=False),
+        sa.Column("filters_json", sa.JSON(), nullable=True),
+        sa.Column("created_by", sa.BigInteger(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column("active", sa.Boolean(), server_default=sa.text("1"), nullable=False),
+    )
+    op.create_table(
+        "cursors",
+        sa.Column("subscription_id", sa.Integer(), sa.ForeignKey("subscriptions.id"), primary_key=True),
+        sa.Column("last_seen_at", sa.DateTime(), nullable=True),
+        sa.Column("last_item_ids_json", sa.JSON(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+    )
+    op.create_table(
+        "relay_log",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("subscription_id", sa.Integer(), sa.ForeignKey("subscriptions.id"), nullable=False),
+        sa.Column("item_id", sa.String(), nullable=False),
+        sa.Column("item_hash", sa.String(), nullable=True),
+        sa.Column("relayed_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+    )
+    op.create_table(
+        "profiles",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("nickname", sa.String(), nullable=False),
+        sa.Column("fl_id", sa.String(), nullable=False, unique=True),
+        sa.Column("last_seen_at", sa.DateTime(), nullable=True),
+    )
+    op.create_table(
+        "events",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("fl_id", sa.String(), nullable=False, unique=True),
+        sa.Column("title", sa.String(), nullable=False),
+        sa.Column("city", sa.String(), nullable=True),
+        sa.Column("region", sa.String(), nullable=True),
+        sa.Column("start_at", sa.DateTime(), nullable=True),
+        sa.Column("permalink", sa.String(), nullable=True),
+        sa.Column("last_populated_at", sa.DateTime(), nullable=True),
+    )
+    op.create_table(
+        "rsvps",
+        sa.Column("event_id", sa.Integer(), sa.ForeignKey("events.id"), primary_key=True),
+        sa.Column("profile_fl_id", sa.String(), primary_key=True),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("seen_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("rsvps")
+    op.drop_table("events")
+    op.drop_table("profiles")
+    op.drop_table("relay_log")
+    op.drop_table("cursors")
+    op.drop_table("subscriptions")
+    op.drop_table("channels")
+    op.drop_table("guilds")

--- a/bot/db.py
+++ b/bot/db.py
@@ -1,0 +1,17 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///bot.db")
+
+engine = create_engine(DATABASE_URL, future=True)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+Base = declarative_base()
+
+def init_db(url: str | None = None):
+    global engine, SessionLocal
+    if url:
+        engine = create_engine(url, future=True)
+        SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    Base.metadata.create_all(bind=engine)
+    return SessionLocal()

--- a/bot/main.py
+++ b/bot/main.py
@@ -20,9 +20,12 @@ TOKEN = os.getenv("DISCORD_TOKEN")
 messages_sent = Counter("discord_messages_sent_total", "Messages sent by bot")
 
 
-async def poll_adapter(sub_id: int, data: Dict[str, Any]):
+async def poll_adapter(db, sub_id: int, data: Dict[str, Any]):
     """Placeholder polling job that would contact adapter service."""
-    # In a real implementation this would make HTTP requests to the adapter.
+    item_id = "sample"
+    if storage.has_relayed(db, sub_id, item_id):
+        return
+    storage.record_relay(db, sub_id, item_id)
     await asyncio.sleep(0)
 
 
@@ -60,7 +63,7 @@ async def fl_subscribe(
     sub_id = storage.add_subscription(
         bot.db, interaction.channel_id, sub_type, target, filters_json
     )
-    bot.scheduler.add_job(poll_adapter, args=[sub_id, filters_json], id=str(sub_id))
+    bot.scheduler.add_job(poll_adapter, args=[bot.db, sub_id, filters_json], id=str(sub_id))
     await interaction.response.send_message(f"Subscribed with id {sub_id}")
 
 

--- a/bot/models.py
+++ b/bot/models.py
@@ -1,0 +1,78 @@
+from sqlalchemy import BigInteger, Boolean, Column, DateTime, ForeignKey, Integer, JSON, String, Text
+from sqlalchemy.sql import func
+
+from .db import Base
+
+
+class Guild(Base):
+    __tablename__ = "guilds"
+    id = Column(BigInteger, primary_key=True)
+    name = Column(String, nullable=True)
+    created_at = Column(DateTime, server_default=func.now(), nullable=False)
+
+
+class Channel(Base):
+    __tablename__ = "channels"
+    id = Column(BigInteger, primary_key=True)
+    guild_id = Column(BigInteger, ForeignKey("guilds.id"), nullable=True)
+    name = Column(String, nullable=True)
+    created_at = Column(DateTime, server_default=func.now(), nullable=False)
+    settings_json = Column(JSON, nullable=True)
+
+
+class Subscription(Base):
+    __tablename__ = "subscriptions"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    channel_id = Column(BigInteger, ForeignKey("channels.id"), nullable=False)
+    type = Column(String, nullable=False)
+    target_id = Column(String, nullable=False)
+    target_kind = Column(String, nullable=False)
+    filters_json = Column(JSON, nullable=True)
+    created_by = Column(BigInteger, nullable=True)
+    created_at = Column(DateTime, server_default=func.now(), nullable=False)
+    active = Column(Boolean, server_default="1", nullable=False)
+
+
+class Cursor(Base):
+    __tablename__ = "cursors"
+    subscription_id = Column(Integer, ForeignKey("subscriptions.id"), primary_key=True)
+    last_seen_at = Column(DateTime, nullable=True)
+    last_item_ids_json = Column(JSON, nullable=True)
+    updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now(), nullable=False)
+
+
+class RelayLog(Base):
+    __tablename__ = "relay_log"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    subscription_id = Column(Integer, ForeignKey("subscriptions.id"), nullable=False)
+    item_id = Column(String, nullable=False)
+    item_hash = Column(String, nullable=True)
+    relayed_at = Column(DateTime, server_default=func.now(), nullable=False)
+
+
+class Profile(Base):
+    __tablename__ = "profiles"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    nickname = Column(String, nullable=False)
+    fl_id = Column(String, unique=True, nullable=False)
+    last_seen_at = Column(DateTime, nullable=True)
+
+
+class Event(Base):
+    __tablename__ = "events"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    fl_id = Column(String, unique=True, nullable=False)
+    title = Column(String, nullable=False)
+    city = Column(String, nullable=True)
+    region = Column(String, nullable=True)
+    start_at = Column(DateTime, nullable=True)
+    permalink = Column(String, nullable=True)
+    last_populated_at = Column(DateTime, nullable=True)
+
+
+class RSVP(Base):
+    __tablename__ = "rsvps"
+    event_id = Column(Integer, ForeignKey("events.id"), primary_key=True)
+    profile_fl_id = Column(String, primary_key=True)
+    status = Column(String, nullable=False)
+    seen_at = Column(DateTime, server_default=func.now(), nullable=False)

--- a/bot/tests/test_storage.py
+++ b/bot/tests/test_storage.py
@@ -1,5 +1,6 @@
+from pathlib import Path
+
 import os
-import sqlite3
 import sys
 from pathlib import Path
 
@@ -9,26 +10,26 @@ from bot import storage
 
 
 def setup_db():
-    conn = storage.init_db(":memory:")
-    return conn
+    db = storage.init_db("sqlite:///:memory:")
+    return db
 
 
 def test_add_and_list_subscription():
-    conn = setup_db()
-    sub_id = storage.add_subscription(conn, 1, "events", "target")
-    subs = storage.list_subscriptions(conn, 1)
+    db = setup_db()
+    sub_id = storage.add_subscription(db, 1, "events", "target")
+    subs = storage.list_subscriptions(db, 1)
     assert subs == [(sub_id, "events", "target")]
 
 
 def test_remove_subscription():
-    conn = setup_db()
-    sub_id = storage.add_subscription(conn, 1, "events", "target")
-    storage.remove_subscription(conn, sub_id, 1)
-    assert storage.list_subscriptions(conn, 1) == []
+    db = setup_db()
+    sub_id = storage.add_subscription(db, 1, "events", "target")
+    storage.remove_subscription(db, sub_id, 1)
+    assert storage.list_subscriptions(db, 1) == []
 
 
 def test_channel_settings():
-    conn = setup_db()
-    storage.set_channel_settings(conn, 1, thread_per_event="on")
-    settings = storage.get_channel_settings(conn, 1)
+    db = setup_db()
+    storage.set_channel_settings(db, 1, thread_per_event="on")
+    settings = storage.get_channel_settings(db, 1)
     assert settings["thread_per_event"] == "on"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+aiohttp
+apscheduler
+discord.py
+python-dotenv
+prometheus-client
+SQLAlchemy
+alembic


### PR DESCRIPTION
## Summary
- set up SQLAlchemy engine with environment-configurable database
- add models, migrations, and requirements for database layer
- refactor storage and bot to use ORM with relay log for idempotency

## Testing
- `make check` *(fails: No rule to make target 'check')*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68961b69b91083328b18c0f96366fc83