### PR TITLE
feat: load YAML configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,17 @@
 FETLIFE_USERNAME=your_username
 FETLIFE_PASSWORD=your_password
+DISCORD_TOKEN=your_token
+
+# Database connection
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=fetlife_bot
+DB_USER=bot_user
+DB_PASSWORD=bot_password
+DATABASE_URL=
+
+# Proxy settings (optional)
 FETLIFE_PROXY=
 FETLIFE_PROXY_TYPE=CURLPROXY_HTTP
-DISCORD_TOKEN=your_token
+FETLIFE_PROXY_USERNAME=
+FETLIFE_PROXY_PASSWORD=

--- a/README.markdown
+++ b/README.markdown
@@ -4,9 +4,34 @@
 
 ## Discord Bot
 
-The `bot/` directory contains a Python application using `discord.py` that relays FetLife updates into Discord. It implements `/fl` slash commands for managing subscriptions and exposes Prometheus metrics at `/metrics`. The bot reads `DISCORD_TOKEN` from a `.env` file.
+The `bot/` directory contains a Python application using `discord.py` that relays FetLife updates into Discord. It implements `/fl` slash commands for managing subscriptions and exposes Prometheus metrics at `/metrics`. Configuration is read from a `.env` file and an optional `config.yaml`.
 
-Run it with:
+### Setup
+
+1. Copy `.env.example` to `.env` and fill in your FetLife credentials, Discord token, database details, and any proxy settings:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+   The `.env` file contains secrets and **must not** be committed to version control.
+
+2. Customize `config.yaml` for per-guild or per-channel defaults. A minimal example:
+
+   ```yaml
+   defaults:
+     thread_per_event: false
+   guilds:
+     "123456789012345678":
+       thread_per_event: true
+       channels:
+         "234567890123456789":
+           attendee_sample: 5
+   ```
+
+   This file is loaded at runtime; avoid storing credentials in it.
+
+Run the bot with:
 
 ```bash
 cd bot

--- a/bot/config.py
+++ b/bot/config.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict
+
+import yaml
+
+
+def load_config(path: str = "config.yaml") -> Dict[str, Any]:
+    cfg_path = Path(path)
+    if not cfg_path.exists():
+        alt = Path(__file__).resolve().parent.parent / path
+        if alt.exists():
+            cfg_path = alt
+        else:
+            return {}
+    with cfg_path.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    return data
+
+
+def get_channel_config(config: Dict[str, Any], guild_id: int | None, channel_id: int) -> Dict[str, Any]:
+    settings: Dict[str, Any] = {}
+    if not config:
+        return settings
+    settings.update(config.get("defaults", {}))
+    if guild_id is None:
+        return settings
+    guild_cfg = config.get("guilds", {}).get(str(guild_id), {})
+    # guild-level settings except channels
+    for key, value in guild_cfg.items():
+        if key != "channels":
+            settings[key] = value
+    channel_cfg = guild_cfg.get("channels", {}).get(str(channel_id), {})
+    settings.update(channel_cfg)
+    return settings

--- a/bot/db.py
+++ b/bot/db.py
@@ -2,7 +2,23 @@ import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import declarative_base, sessionmaker
 
-DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///bot.db")
+
+def _build_url() -> str:
+    if url := os.getenv("DATABASE_URL"):
+        return url
+    host = os.getenv("DB_HOST")
+    name = os.getenv("DB_NAME")
+    if host and name:
+        user = os.getenv("DB_USER", "")
+        password = os.getenv("DB_PASSWORD", "")
+        port = os.getenv("DB_PORT", "")
+        auth = f"{user}:{password}@" if user else ""
+        port_part = f":{port}" if port else ""
+        return f"postgresql://{auth}{host}{port_part}/{name}"
+    return "sqlite:///bot.db"
+
+
+DATABASE_URL = _build_url()
 
 engine = create_engine(DATABASE_URL, future=True)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)

--- a/bot/tests/test_config.py
+++ b/bot/tests/test_config.py
@@ -1,0 +1,27 @@
+import pathlib
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
+
+from bot.config import get_channel_config, load_config
+
+
+def test_load_config(tmp_path):
+    cfg_file = tmp_path / "config.yaml"
+    cfg_file.write_text("defaults:\n  foo: bar\n")
+    cfg = load_config(str(cfg_file))
+    assert cfg["defaults"]["foo"] == "bar"
+
+
+def test_get_channel_config():
+    cfg = {
+        "defaults": {"a": 1},
+        "guilds": {
+            "1": {
+                "b": 2,
+                "channels": {"10": {"c": 3}},
+            }
+        },
+    }
+    result = get_channel_config(cfg, 1, 10)
+    assert result == {"a": 1, "b": 2, "c": 3}

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,12 @@
+# Default settings applied to all channels
+defaults:
+  thread_per_event: false
+
+# Per-guild overrides
+# Replace the IDs below with your guild and channel IDs
+# guilds:
+#   "123456789012345678":
+#     thread_per_event: true
+#     channels:
+#       "234567890123456789":
+#         attendee_sample: 5

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ python-dotenv
 prometheus-client
 SQLAlchemy
 alembic
+PyYAML


### PR DESCRIPTION
## Summary
- load optional YAML config for per-guild and per-channel overrides
- support database credentials via environment variables
- document setup, env usage, and secret handling

## Testing
- `pytest -q`
- `make check` *(fails: No rule to make target 'check')*

------
https://chatgpt.com/codex/tasks/task_e_68961ffc872c8332a54dd4f0bfb8daba