### PR TITLE
feat: add structured logging and metrics

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4,7 +4,7 @@
 
 ## Discord Bot
 
-The `bot/` directory contains a Python application using `discord.py` that relays FetLife updates into Discord. It implements `/fl` slash commands for managing subscriptions and exposes Prometheus metrics at `/metrics`. Configuration is read from a `.env` file and an optional `config.yaml`.
+The `bot/` directory contains a Python application using `discord.py` that relays FetLife updates into Discord. It implements `/fl` slash commands for managing subscriptions and exposes Prometheus metrics at `/metrics` plus a readiness probe at `/ready`. Metrics include counters such as `fetlife_requests_total`, `discord_messages_sent_total`, and `duplicates_suppressed_total` as well as histograms like `poll_cycle_seconds` and gauges such as `rate_limit_tokens`. Configuration is read from a `.env` file and an optional `config.yaml`.
 
 ### Setup
 
@@ -215,7 +215,7 @@ Are you using `libFetLife`? [Let me know](http://maybemaimed.com/seminars/#booki
 ## Adapter HTTP Service
 
 The `adapter/` directory provides a small Slim-based HTTP service that wraps `FetLife.php`.
-It reads credentials from environment variables (`FETLIFE_USERNAME`, `FETLIFE_PASSWORD`, `FETLIFE_PROXY`, `FETLIFE_PROXY_TYPE`).
+It reads credentials from environment variables (`FETLIFE_USERNAME`, `FETLIFE_PASSWORD`, `FETLIFE_PROXY`, `FETLIFE_PROXY_TYPE`) and exposes a `/healthz` endpoint along with Prometheus metrics at `/metrics`.
 
 ### OpenAPI
 

--- a/bot/main.py
+++ b/bot/main.py
@@ -1,6 +1,9 @@
 import asyncio
 import json
 import os
+import time
+import logging
+from datetime import datetime
 from typing import Any, Dict
 
 import discord
@@ -9,7 +12,13 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from discord import app_commands
 from discord.ext import commands
 from dotenv import load_dotenv
-from prometheus_client import CONTENT_TYPE_LATEST, Counter, generate_latest
+from prometheus_client import (
+    CONTENT_TYPE_LATEST,
+    Counter,
+    Gauge,
+    Summary,
+    generate_latest,
+)
 
 from . import storage
 from .config import get_channel_config, load_config
@@ -17,36 +26,84 @@ from .config import get_channel_config, load_config
 load_dotenv()
 TOKEN = os.getenv("DISCORD_TOKEN")
 
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:  # pragma: no cover - formatting
+        base = {
+            "level": record.levelname,
+            "name": record.name,
+            "message": record.getMessage(),
+        }
+        return json.dumps(base)
+
+
+handler = logging.StreamHandler()
+handler.setFormatter(JsonFormatter())
+logging.basicConfig(level=logging.INFO, handlers=[handler])
+logger = logging.getLogger("flbot")
+
+
 # Metrics
 messages_sent = Counter("discord_messages_sent_total", "Messages sent by bot")
+fetlife_requests = Counter("fetlife_requests_total", "Requests made to FetLife")
+poll_cycle = Summary("poll_cycle_seconds", "Duration of poll cycles")
+duplicates_suppressed = Counter(
+    "duplicates_suppressed_total", "Duplicate messages not relayed"
+)
+rate_limit_tokens = Gauge(
+    "rate_limit_tokens", "Tokens currently available in rate limiter"
+)
+
+rate_limiter = asyncio.Semaphore(5)
+
+fl_group = app_commands.Group(name="fl", description="FetLife commands")
+
+
 
 
 async def poll_adapter(db, sub_id: int, data: Dict[str, Any]):
     """Placeholder polling job that would contact adapter service."""
-    item_id = "sample"
-    if storage.has_relayed(db, sub_id, item_id):
-        return
-    storage.record_relay(db, sub_id, item_id)
-    await asyncio.sleep(0)
+    start = time.perf_counter()
+    await rate_limiter.acquire()
+    rate_limit_tokens.set(rate_limiter._value)
+    try:
+        item_id = "sample"
+        fetlife_requests.inc()
+        if storage.has_relayed(db, sub_id, item_id):
+            duplicates_suppressed.inc()
+            logger.info("duplicate", extra={"sub_id": sub_id, "item": item_id})
+            return
+        storage.record_relay(db, sub_id, item_id)
+        await asyncio.sleep(0)
+    finally:
+        poll_cycle.observe(time.perf_counter() - start)
+        rate_limiter.release()
+        rate_limit_tokens.set(rate_limiter._value)
+        bot.last_poll = time.time()
 
 
 class FLBot(commands.Bot):
     def __init__(self) -> None:
         intents = discord.Intents.default()
         super().__init__(command_prefix="/", intents=intents)
-        self.tree.add_command(fl_group)
         self.db = storage.init_db()
         self.scheduler = AsyncIOScheduler()
         self.config = load_config()
+        self.last_poll = 0.0
 
     async def setup_hook(self) -> None:
         self.scheduler.start()
 
 
 bot = FLBot()
+ready_flag = False
 
 
-fl_group = app_commands.Group(name="fl", description="FetLife commands")
+@bot.event
+async def on_ready() -> None:
+    global ready_flag
+    ready_flag = True
+    logger.info("bot_ready", extra={"user": str(bot.user)})
 
 
 @fl_group.command(name="login", description="Validate adapter service connectivity")
@@ -118,7 +175,15 @@ async def fl_settings(
 
 @fl_group.command(name="health", description="Show adapter health")
 async def fl_health(interaction: discord.Interaction) -> None:
-    await interaction.response.send_message("Adapter OK; jobs: %d" % len(bot.scheduler.get_jobs()))
+    depth = len(bot.scheduler.get_jobs())
+    last = (
+        datetime.utcfromtimestamp(bot.last_poll).isoformat()
+        if bot.last_poll
+        else "never"
+    )
+    await interaction.response.send_message(
+        f"last_poll: {last}; queue_depth: {depth}"
+    )
 
 
 @fl_group.command(name="purge", description="Purge local caches")
@@ -131,11 +196,18 @@ async def metrics_handler(request: web.Request) -> web.Response:
     return web.Response(body=data, content_type=CONTENT_TYPE_LATEST)
 
 
+async def ready_handler(request: web.Request) -> web.Response:
+    if ready_flag:
+        return web.Response(text="ok")
+    return web.Response(status=503, text="not ready")
+
+
 async def main() -> None:
     if not TOKEN:
         raise RuntimeError("DISCORD_TOKEN is not set")
     app = web.Application()
     app.router.add_get("/metrics", metrics_handler)
+    app.router.add_get("/ready", ready_handler)
     runner = web.AppRunner(app)
     await runner.setup()
     site = web.TCPSite(runner, "0.0.0.0", 8000)

--- a/bot/tests/test_metrics.py
+++ b/bot/tests/test_metrics.py
@@ -1,0 +1,21 @@
+import asyncio
+
+from bot import storage
+from bot.main import duplicates_suppressed, fetlife_requests, poll_adapter
+
+
+def test_poll_metrics():
+    fetlife_requests._value.set(0)
+    duplicates_suppressed._value.set(0)
+    db = storage.init_db("sqlite:///:memory:")
+    sub_id = storage.add_subscription(db, 1, "events", "target")
+
+    async def run() -> None:
+        await poll_adapter(db, sub_id, {})
+        await poll_adapter(db, sub_id, {})
+
+    asyncio.run(run())
+
+    assert fetlife_requests._value.get() == 2
+    assert duplicates_suppressed._value.get() == 1
+


### PR DESCRIPTION
## Summary
- add JSON logging and Prometheus metrics to adapter
- instrument bot with structured logs, rate limiting, and health metrics
- document new `/ready`, `/metrics`, and `/healthz` endpoints

## Testing
- `pytest`
- `phpunit tests/FetLifeUserTest.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896253147b083329fa62dbbe26af458