### PR TITLE
feat: add polling scheduler and rate limits

### DIFF
--- a/bot/rate_limit.py
+++ b/bot/rate_limit.py
@@ -1,0 +1,30 @@
+import asyncio
+import time
+
+class TokenBucket:
+    """Asynchronous token bucket rate limiter."""
+
+    def __init__(self, capacity: int, refill_rate: float) -> None:
+        self.capacity = capacity
+        self.refill_rate = refill_rate
+        self.tokens = float(capacity)
+        self.updated = time.monotonic()
+        self._lock = asyncio.Lock()
+
+    async def acquire(self, tokens: float = 1) -> None:
+        async with self._lock:
+            await self._add_new_tokens()
+            while self.tokens < tokens:
+                await asyncio.sleep((tokens - self.tokens) / self.refill_rate)
+                await self._add_new_tokens()
+            self.tokens -= tokens
+
+    async def _add_new_tokens(self) -> None:
+        now = time.monotonic()
+        delta = now - self.updated
+        if delta > 0:
+            self.tokens = min(self.capacity, self.tokens + delta * self.refill_rate)
+            self.updated = now
+
+    def get_tokens(self) -> float:
+        return self.tokens

--- a/bot/storage.py
+++ b/bot/storage.py
@@ -74,6 +74,26 @@ def get_channel_settings(db: Session, channel_id: int) -> Dict[str, Any]:
     return channel.settings_json or {} if channel else {}
 
 
+def get_cursor(db: Session, sub_id: int) -> Tuple[Any | None, list[str]]:
+    cur = db.get(models.Cursor, sub_id)
+    if not cur:
+        return None, []
+    ids = cur.last_item_ids_json or []
+    return cur.last_seen_at, ids
+
+
+def update_cursor(
+    db: Session, sub_id: int, last_seen_at: Any, last_item_ids: list[str]
+) -> None:
+    cur = db.get(models.Cursor, sub_id)
+    if not cur:
+        cur = models.Cursor(subscription_id=sub_id)
+        db.add(cur)
+    cur.last_seen_at = last_seen_at
+    cur.last_item_ids_json = last_item_ids
+    db.commit()
+
+
 def has_relayed(db: Session, sub_id: int, item_id: str) -> bool:
     return (
         db.query(models.RelayLog)

--- a/bot/tests/test_cursor.py
+++ b/bot/tests/test_cursor.py
@@ -1,0 +1,23 @@
+import sys
+from datetime import datetime
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from bot import storage
+
+
+def setup_db():
+    return storage.init_db("sqlite:///:memory:")
+
+
+def test_cursor_roundtrip():
+    db = setup_db()
+    sub_id = storage.add_subscription(db, 1, "events", "target")
+    last_seen, ids = storage.get_cursor(db, sub_id)
+    assert last_seen is None and ids == []
+    now = datetime.utcnow()
+    storage.update_cursor(db, sub_id, now, ["a", "b"])
+    last_seen, ids = storage.get_cursor(db, sub_id)
+    assert ids == ["a", "b"]
+    assert last_seen == now

--- a/bot/tests/test_rate_limit.py
+++ b/bot/tests/test_rate_limit.py
@@ -1,0 +1,21 @@
+import asyncio
+import time
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from bot.rate_limit import TokenBucket
+
+
+@pytest.mark.asyncio
+async def test_token_bucket_refill():
+    bucket = TokenBucket(2, 1)  # 2 tokens, 1 per second refill
+    await bucket.acquire()
+    await bucket.acquire()
+    start = time.perf_counter()
+    await bucket.acquire()
+    elapsed = time.perf_counter() - start
+    assert elapsed >= 1


### PR DESCRIPTION
## Summary
- add token bucket rate limiters for adapter and bot
- schedule subscription polling with jitter, backoff, and cursor caching
- test cursor storage and token bucket behavior

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68962af86aac8332b403e15eb63946e7