### PR TITLE
test: add command parsing and contract tests

### DIFF
--- a/bot/adapter_client.py
+++ b/bot/adapter_client.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from typing import Any, List
+
+import aiohttp
+
+
+async def fetch_events(base_url: str, location: str) -> List[Any]:
+    """Fetch events from adapter service."""
+    async with aiohttp.ClientSession() as session:
+        async with session.get(f"{base_url}/events", params={"location": location}) as resp:
+            resp.raise_for_status()
+            return await resp.json()

--- a/bot/tests/fixtures/event.json
+++ b/bot/tests/fixtures/event.json
@@ -1,0 +1,8 @@
+{
+  "id": 1,
+  "title": "Test Event",
+  "link": "https://fetlife.com/events/1",
+  "time": "2024-01-01T00:00:00Z",
+  "city": "NYC",
+  "attendees": 15
+}

--- a/bot/tests/fixtures/group_post.json
+++ b/bot/tests/fixtures/group_post.json
@@ -1,0 +1,6 @@
+{
+  "id": 3,
+  "title": "Group Topic",
+  "link": "https://fetlife.com/groups/1/group_posts/3",
+  "published": "2024-03-01T00:00:00Z"
+}

--- a/bot/tests/fixtures/writing.json
+++ b/bot/tests/fixtures/writing.json
@@ -1,0 +1,6 @@
+{
+  "id": 2,
+  "title": "My Post",
+  "link": "https://fetlife.com/writings/2",
+  "published": "2024-02-01T00:00:00Z"
+}

--- a/bot/tests/test_adapter_client.py
+++ b/bot/tests/test_adapter_client.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import asyncio
+from unittest.mock import patch
+
+from bot.adapter_client import fetch_events
+
+
+class DummyResp:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def json(self):
+        return [{"id": 1}]
+
+    def raise_for_status(self):
+        pass
+
+
+class DummySession:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    def get(self, url, params=None):
+        return DummyResp()
+
+
+def test_fetch_events_mocked():
+    with patch("aiohttp.ClientSession", return_value=DummySession()):
+        events = asyncio.run(fetch_events("http://adapter", "cities/1"))
+    assert events == [{"id": 1}]

--- a/bot/tests/test_adapter_contract.py
+++ b/bot/tests/test_adapter_contract.py
@@ -1,0 +1,33 @@
+import sys
+import json
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from jsonschema import validate
+
+FIXTURES = Path(__file__).parent / "fixtures"
+SCHEMAS = Path(__file__).resolve().parents[2] / "schemas"
+
+
+def load(name: str, base: Path) -> dict:
+    with (base / name).open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def test_event_contract():
+    data = load("event.json", FIXTURES)
+    schema = load("event.json", SCHEMAS)
+    validate(instance=data, schema=schema)
+
+
+def test_writing_contract():
+    data = load("writing.json", FIXTURES)
+    schema = load("writing.json", SCHEMAS)
+    validate(instance=data, schema=schema)
+
+
+def test_group_post_contract():
+    data = load("group_post.json", FIXTURES)
+    schema = load("group_post.json", SCHEMAS)
+    validate(instance=data, schema=schema)

--- a/bot/tests/test_rate_limit.py
+++ b/bot/tests/test_rate_limit.py
@@ -3,19 +3,19 @@ import time
 import sys
 from pathlib import Path
 
-import pytest
-
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 from bot.rate_limit import TokenBucket
 
 
-@pytest.mark.asyncio
-async def test_token_bucket_refill():
-    bucket = TokenBucket(2, 1)  # 2 tokens, 1 per second refill
-    await bucket.acquire()
-    await bucket.acquire()
-    start = time.perf_counter()
-    await bucket.acquire()
-    elapsed = time.perf_counter() - start
-    assert elapsed >= 1
+def test_token_bucket_refill():
+    async def run():
+        bucket = TokenBucket(2, 1)  # 2 tokens, 1 per second refill
+        await bucket.acquire()
+        await bucket.acquire()
+        start = time.perf_counter()
+        await bucket.acquire()
+        elapsed = time.perf_counter() - start
+        assert elapsed >= 1
+
+    asyncio.run(run())

--- a/bot/tests/test_utils.py
+++ b/bot/tests/test_utils.py
@@ -1,0 +1,41 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import discord
+
+from bot.utils import (
+    format_event_embed,
+    matches_filters,
+    parse_subscribe_command,
+)
+
+
+def test_parse_subscribe_command():
+    sub_type, target, filters = parse_subscribe_command("events location:cities/1 min_attendees:10 keywords:rope,consent")
+    assert sub_type == "events"
+    assert target == "location:cities/1"
+    assert filters == {"min_attendees": 10, "keywords": ["rope", "consent"]}
+
+
+def test_matches_filters():
+    filters = {"keywords": ["rope"], "city": "NYC", "min_attendees": 5}
+    item = {"title": "Rope Night", "city": "NYC", "attendees": 10}
+    assert matches_filters(item, filters)
+    item2 = {"title": "Other", "city": "NYC", "attendees": 10}
+    assert not matches_filters(item2, filters)
+
+
+def test_format_event_embed():
+    event = {
+        "title": "Party",
+        "link": "https://example.com",
+        "time": "2024-01-01",
+    }
+    embed = format_event_embed(event)
+    assert isinstance(embed, discord.Embed)
+    assert embed.title == "📅 Party"
+    assert embed.description == "https://example.com"
+    assert embed.fields[0].name == "Time"
+    assert embed.fields[0].value == "2024-01-01"

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+import discord
+
+
+def parse_subscribe_command(text: str) -> Tuple[str, str, Dict[str, Any]]:
+    """Parse a simplified subscribe command string.
+
+    Example: "events location:cities/5898 radius_km:50 keywords:rope,consent"
+    """
+    parts = text.strip().split()
+    if len(parts) < 2:
+        raise ValueError("command requires type and target")
+    sub_type = parts[0]
+    target = parts[1]
+    filters: Dict[str, Any] = {}
+    for part in parts[2:]:
+        if ":" not in part:
+            continue
+        key, value = part.split(":", 1)
+        if key == "keywords":
+            filters[key] = [v.strip() for v in value.split(",") if v.strip()]
+        elif value.isdigit():
+            filters[key] = int(value)
+        else:
+            filters[key] = value
+    return sub_type, target, filters
+
+
+def matches_filters(item: Dict[str, Any], filters: Dict[str, Any]) -> bool:
+    """Return True if *item* satisfies *filters*.
+
+    Supported filters: keywords (list), city (str), min_attendees (int).
+    """
+    keywords: List[str] = filters.get("keywords", [])
+    if keywords:
+        haystack = " ".join(str(v) for v in item.values()).lower()
+        if not any(k.lower() in haystack for k in keywords):
+            return False
+    city = filters.get("city")
+    if city and item.get("city", "").lower() != str(city).lower():
+        return False
+    min_attendees = filters.get("min_attendees")
+    if (
+        isinstance(min_attendees, int)
+        and int(item.get("attendees", 0)) < min_attendees
+    ):
+        return False
+    return True
+
+
+def format_event_embed(event: Dict[str, Any]) -> discord.Embed:
+    """Return a Discord embed for *event*."""
+    title = f"\U0001F4C5 {event.get('title', '')}"
+    description = event.get("link", "")
+    embed = discord.Embed(title=title, description=description)
+    if "time" in event:
+        embed.add_field(name="Time", value=str(event["time"]))
+    return embed

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ prometheus-client
 SQLAlchemy
 alembic
 PyYAML
+jsonschema

--- a/schemas/event.json
+++ b/schemas/event.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["id", "title", "link", "time"],
+  "properties": {
+    "id": {"type": "integer"},
+    "title": {"type": "string"},
+    "link": {"type": "string"},
+    "time": {"type": ["string", "null"]}
+  }
+}

--- a/schemas/group_post.json
+++ b/schemas/group_post.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["id", "title", "link", "published"],
+  "properties": {
+    "id": {"type": "integer"},
+    "title": {"type": "string"},
+    "link": {"type": "string"},
+    "published": {"type": ["string", "null"]}
+  }
+}

--- a/schemas/writing.json
+++ b/schemas/writing.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["id", "title", "link", "published"],
+  "properties": {
+    "id": {"type": "integer"},
+    "title": {"type": "string"},
+    "link": {"type": "string"},
+    "published": {"type": ["string", "null"]}
+  }
+}

--- a/tests/FetLifeUserTest.php
+++ b/tests/FetLifeUserTest.php
@@ -3,19 +3,28 @@ class FetLifeUserTest extends PHPUnit_Framework_TestCase {
 
     protected static $FL;
 
-    // TODO: Use mock/stubs instead of sharing a static $FL and
-    //       making live HTTP requests?
     public static function setUpBeforeClass () {
-        global $fetlife_username, $fetlife_password, $fetlife_proxyurl;
-        self::$FL = new FetLifeUser($fetlife_username, $fetlife_password);
-        if ('auto' === $fetlife_proxyurl) {
+        $username = getenv('FETLIFE_USERNAME');
+        $password = getenv('FETLIFE_PASSWORD');
+        $proxyurl = getenv('FETLIFE_PROXYURL');
+        if (!$username || !$password) {
+            return;
+        }
+        self::$FL = new FetLifeUser($username, $password);
+        if ('auto' === $proxyurl) {
             self::$FL->connection->setProxy('auto');
-        } else if ($fetlife_proxyurl) {
-            $p = parse_url($fetlife_proxyurl);
+        } else if ($proxyurl) {
+            $p = parse_url($proxyurl);
             self::$FL->connection->setProxy(
                 "{$p['host']}:{$p['port']}",
                 ('socks' === $p['scheme']) ? CURLPROXY_SOCKS5 : CURLPROXY_HTTP
             );
+        }
+    }
+
+    protected function setUp(): void {
+        if (!self::$FL) {
+            $this->markTestSkipped('FetLife credentials not provided');
         }
     }
 

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -1,0 +1,7 @@
+<phpunit bootstrap="bootstrap.php" convertNoticesToExceptions="false">
+    <php>
+        <env name="FETLIFE_USERNAME" value="%FETLIFE_USERNAME%" />
+        <env name="FETLIFE_PASSWORD" value="%FETLIFE_PASSWORD%" />
+        <env name="FETLIFE_PROXYURL" value="%FETLIFE_PROXYURL%" />
+    </php>
+</phpunit>


### PR DESCRIPTION
## Summary
- add parsing, filter, and embed utilities with unit tests
- validate adapter responses against JSON schemas
- configure phpunit for optional live FetLife tests and mock adapter calls

## Testing
- `pytest`
- `phpunit -c tests/phpunit.xml`

------
https://chatgpt.com/codex/tasks/task_e_68962eef023083329f3846d29b1707f9