### PR TITLE
chore: add docker and compose setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: check
+
+check:
+	docker compose build
+	docker compose run --rm bot flake8 bot
+	docker compose run --rm bot pytest
+	docker compose run --rm adapter vendor/bin/phpunit

--- a/adapter/Dockerfile
+++ b/adapter/Dockerfile
@@ -1,0 +1,20 @@
+FROM php:8.2-cli
+
+WORKDIR /app
+
+# Install composer
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+
+# Install PHP dependencies
+COPY composer.json composer.lock ./
+RUN composer install --no-interaction --prefer-dist
+
+# Copy source and public files
+COPY src/ src/
+COPY adapter/public/ public/
+
+EXPOSE 8000
+CMD ["php", "-S", "0.0.0.0:8000", "-t", "public"]

--- a/bot/Dockerfile
+++ b/bot/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:18-bullseye
+
+WORKDIR /app
+
+# Install Python
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends python3 python3-pip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Python dependencies
+COPY requirements.txt ./
+RUN pip3 install --no-cache-dir -r requirements.txt \
+    && pip3 install --no-cache-dir pytest flake8
+
+COPY bot/ bot/
+
+EXPOSE 3000
+CMD ["python3", "bot/main.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3.9'
+
+services:
+  db:
+    image: postgres:15
+    restart: unless-stopped
+    env_file: .env
+    environment:
+      POSTGRES_DB: ${DB_NAME}
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+  adapter:
+    build:
+      context: .
+      dockerfile: adapter/Dockerfile
+    env_file: .env
+    depends_on:
+      - db
+    ports:
+      - "8000:8000"
+
+  bot:
+    build:
+      context: .
+      dockerfile: bot/Dockerfile
+    env_file: .env
+    depends_on:
+      - adapter
+      - db
+    command: ["python3", "bot/main.py"]
+
+volumes:
+  db_data:


### PR DESCRIPTION
## Summary
- add PHP adapter Dockerfile using built-in server
- add Node/Python bot Dockerfile with lint and test deps
- add docker-compose with Postgres and env/volume wiring
- add Makefile `check` target running lint and tests in containers

## Testing
- `make check` *(fails: make: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68973ac52c208332a7e0fc4d2b47ac9d