### PR TITLE
refactor: consolidate SQLAlchemy imports

### DIFF
--- a/bot/models.py
+++ b/bot/models.py
@@ -1,5 +1,14 @@
-from sqlalchemy import BigInteger, Boolean, Column, DateTime, ForeignKey, Integer, JSON, String, Text
-from sqlalchemy.sql import func
+from sqlalchemy import (
+    Column,
+    Integer,
+    String,
+    DateTime,
+    Boolean,
+    JSON,
+    BigInteger,
+    ForeignKey,
+    func,
+)
 
 from .db import Base
 


### PR DESCRIPTION
## Summary
- centralize SQLAlchemy field imports in `bot/models.py`

## Testing
- `make check` *(fails: docker: No such file or directory)*
- `docker-compose build` *(fails: Error while fetching server API version: ('Connection aborted.', FileNotFoundError(2, 'No such file or directory')))*
- `flake8 bot` *(fails: E501 line too long, etc.)*
- `pytest`
- `vendor/bin/phpunit` *(shows usage information)*

------
https://chatgpt.com/codex/tasks/task_e_68974349cf8c833299637be4d4c941a3