### PR TITLE
docs(contrib): add commit-msg hook instructions (v0.1.6)

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -353,6 +353,12 @@ Run make check (lint, tests, schema) before PR.
 
 Follow semantic commits and Conventional Changelog.
 
+Install the commit-msg hook to enforce Conventional Commits:
+
+```bash
+cp scripts/commit-msg .git/hooks/commit-msg && chmod +x .git/hooks/commit-msg
+```
+
 18) Risk Register (tl;dr)
 ToS/Access: Authentication may break if site changes → adapter abstraction + schema tests.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+### Added
+- commit-msg git hook enforcing Conventional Commits with installation instructions.
+
 ## [0.1.6] - 2025-08-10
 ### Added
 - CI release-hygiene workflow running make check, version/changelog verification, and Agents drift check.

--- a/docs/decisions/2025-08-10.md
+++ b/docs/decisions/2025-08-10.md
@@ -1,0 +1,11 @@
+# 2025-08-10 - Commit message hook
+
+## Context
+Commit messages were manually checked, risking non-standard history.
+
+## Decision
+Provide a Conventional Commits validator via a commit-msg git hook and document installation steps in Agents.md.
+
+## Consequences
+- Ensures commit history follows agreed conventions.
+- Requires contributors to install the hook locally.

--- a/plan.md
+++ b/plan.md
@@ -1,20 +1,20 @@
 # Plan
 
 ## Goal
-Add CI workflows for release hygiene and automated tagging.
+Add a commit-msg git hook enforcing Conventional Commits and document installation steps for contributors.
 
 ## Constraints
-- release-hygiene must run `make check`, verify `pyproject.toml` version against `CHANGELOG.md`, and run AGENTS drift script.
-- release workflow tags releases from main and publishes notes.
-- Follow semantic versioning and Keep a Changelog.
+- Hook must validate commit messages against Conventional Commits regex.
+- Instructions belong in Agents.md per repository guidelines.
+- Maintain changelog entry without releasing a new version.
 
 ## Risks
-- `make check` may fail due to missing Docker or dependencies.
-- Tag creation can fail if the tag already exists.
+- Contributors may skip installing the hook and experience commit failures later.
+- Hook script may not be portable across all shells.
 
 ## Test Plan
 - `make check`
 - `scripts/agents-verify.sh`
 
 ## Semver
-Patch bump to v0.1.6.
+Patch; documentation and tooling only.

--- a/scripts/commit-msg
+++ b/scripts/commit-msg
@@ -1,0 +1,7 @@
+#!/bin/sh
+msgfile="$1"
+msg="$(cat "$msgfile")"
+if ! grep -Eq '^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\(.+\))?: ' "$msgfile"; then
+  echo "Commit must follow Conventional Commits. e.g., 'feat(parser): add XYZ'" >&2
+  exit 1
+fi


### PR DESCRIPTION
### Summary
- document Conventional Commits `commit-msg` hook installation for contributors
- add `commit-msg` hook script enforcing commit message format

### SemVer
- [x] patch (bugfix)
- [ ] minor (backwards-compatible feature)
- [ ] major (breaking change)
Reason: documentation and developer tooling only

### Checks
- [ ] Updated version file(s)
- [x] Updated CHANGELOG.md
- [ ] Tests/CI green
- [x] AGENTS.md synced with reality


------
https://chatgpt.com/codex/tasks/task_e_68988738a33483329672cbf8a386984a