### PR TITLE
fix(adapter): clean up temp cookie files (v0.1.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+## [0.1.8] - 2025-08-11
+### Fixed
+- Clean up temporary cookie files after login and during tests.
+### Added
+- PHPUnit test ensuring cookie file removal.
+
 ## [0.1.7] - 2025-08-10
 ### Added
 - commit-msg git hook enforcing Conventional Commits with installation instructions.

--- a/adapter/public/index.php
+++ b/adapter/public/index.php
@@ -45,6 +45,7 @@ function getUser()
     }
     $data = $_SESSION['fetlife'];
     $cookieFile = tempnam(sys_get_temp_dir(), 'fl');
+    register_shutdown_function('unlink', $cookieFile);
     if (isset($data['cookie'])) {
         file_put_contents($cookieFile, $data['cookie']);
     }
@@ -64,6 +65,7 @@ $app->post('/login', function ($request, $response) {
         return $response->withStatus(400)->withHeader('Content-Type', 'application/json');
     }
     $cookieFile = tempnam(sys_get_temp_dir(), 'fl');
+    register_shutdown_function('unlink', $cookieFile);
     $user = new FetLifeUser($username, $password, new Connection($cookieFile));
     if (!empty($_ENV['FETLIFE_PROXY'])) {
         $type = $_ENV['FETLIFE_PROXY_TYPE'] ?? CURLPROXY_HTTP;

--- a/docs/decisions/2025-08-11.md
+++ b/docs/decisions/2025-08-11.md
@@ -1,0 +1,10 @@
+# 2025-08-11
+
+## Context
+Temporary cookie files created for FetLife sessions were not cleaned up, risking buildup on disk.
+
+## Decision
+Register cleanup of cookie files via `register_shutdown_function` and destructor in `Connection` and add tests to ensure removal.
+
+## Consequences
+Ensures no stale session files remain and provides regression coverage.

--- a/plan.md
+++ b/plan.md
@@ -1,18 +1,18 @@
 # Plan
 
 ## Goal
-Handle invalid JSON in filter parsing within the `/fl subscribe` command and cover it with tests.
+Ensure temporary cookie files are cleaned up and verify removal with PHPUnit.
 
 ## Constraints
-- Follow existing logging and rate limit patterns in `fl_subscribe`.
-- Maintain repository conventions including changelog and version updates.
+- Follow repository conventions including changelog, version bump, and tests.
+- Maintain existing login flow without external network dependencies in tests.
 
 ## Risks
-- Misplaced error handling could still raise uncaught exceptions.
-- Additional test may require event loop setup and mocking scheduler.
+- Improper cleanup could leave lingering files.
+- Test may need to mock network interactions.
 
 ## Test Plan
 - `make check`
 
 ## Semver
-Patch: backwards compatible bug fix.
+Patch: backward-compatible bug fix.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fetlife-discord-bot"
-version = "0.1.7"
+version = "0.1.8"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 classifiers = [

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -15,6 +15,23 @@ class Connection implements ConnectionInterface
     public function __construct(?string $cookieFile = null)
     {
         $this->cookieFile = $cookieFile ?? tempnam(sys_get_temp_dir(), 'fl');
+        register_shutdown_function(static function (string $file): void {
+            if (file_exists($file)) {
+                @unlink($file);
+            }
+        }, $this->cookieFile);
+    }
+
+    public function __destruct()
+    {
+        if (file_exists($this->cookieFile)) {
+            @unlink($this->cookieFile);
+        }
+    }
+
+    public function getCookieFile(): string
+    {
+        return $this->cookieFile;
     }
 
     public function logIn(string $nickname, string $password): string

--- a/tests/CookieCleanupTest.php
+++ b/tests/CookieCleanupTest.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace FetLife\Tests;
+
+use FetLife\Connection;
+use FetLife\User;
+use PHPUnit\Framework\TestCase;
+
+final class CookieCleanupTest extends TestCase
+{
+    public function testCookieFileRemovedAfterLoginAndUnset(): void
+    {
+        $conn = new class extends Connection {
+            public function logIn(string $nickname, string $password): string
+            {
+                return '<script>FetLife.currentUser.id = 1;</script>';
+            }
+            public function get(string $path): string
+            {
+                return '';
+            }
+            public function findUserId(string $html): ?int
+            {
+                return 1;
+            }
+            public function findUserNickname(string $html): ?string
+            {
+                return 'tester';
+            }
+        };
+        $path = $conn->getCookieFile();
+        $user = new User('tester', 'secret', $conn);
+        $user->logIn();
+        unset($user, $conn);
+        $this->assertFileDoesNotExist($path);
+    }
+}


### PR DESCRIPTION
### Summary
- remove temp cookie files after login
- cover cookie cleanup with phpunit test

### SemVer
- [x] patch
- [ ] minor
- [ ] major
Reason: backwards-compatible bug fix.

### Checks
- [x] Updated version file(s)
- [x] Updated CHANGELOG.md
- [ ] Tests/CI green
- [x] AGENTS.md synced with reality


------
https://chatgpt.com/codex/tasks/task_e_6899dcc14b58833288013589ad67d62d