### PR TITLE
feat(bot): relay events and writings as embeds (v0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+## [0.3.0] - 2025-08-11
+### Added
+- Relay events and user writings as Discord embeds during polling.
+
 ## [0.2.0] - 2025-08-11
 ### Added
 - Adapter client helpers for fetching user writings and group posts.

--- a/bot/adapter_client.py
+++ b/bot/adapter_client.py
@@ -1,13 +1,12 @@
 from __future__ import annotations
-from __future__ import annotations
 
-from typing import Any, List
+from typing import Any
 
 import aiohttp
 
 
-async def fetch_events(base_url: str, location: str) -> List[Any]:
-    """Fetch events from adapter service."""
+async def fetch_events(base_url: str, location: str) -> list[dict[str, Any]]:
+    """Fetch events from the adapter service."""
     async with aiohttp.ClientSession() as session:
         async with session.get(f"{base_url}/events", params={"location": location}) as resp:
             resp.raise_for_status()

--- a/bot/tests/test_poll_adapter.py
+++ b/bot/tests/test_poll_adapter.py
@@ -1,5 +1,5 @@
-import asyncio
 from pathlib import Path
+import asyncio
 import sys
 from unittest.mock import AsyncMock, patch
 
@@ -9,26 +9,49 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 from bot import main, storage, models  # noqa: E402
 
 
-async def run_poll(db, sub_id, events, data, error=False):
-    fetch_mock = AsyncMock(return_value=events)
+async def run_poll(
+    db, sub_id, items, data, fetch_fn="fetch_events", error=False, channel=None
+):
+    fetch_mock = AsyncMock(return_value=items)
     if error:
         fetch_mock = AsyncMock(side_effect=aiohttp.ClientError())
-    with patch("bot.main.adapter_client.fetch_events", fetch_mock):
-        with patch.object(
-            main.bot.scheduler,
-            "add_job",
-        ):
-            await main.poll_adapter(db, sub_id, data)
+    if channel is None:
+        channel = AsyncMock()
+        channel.send = AsyncMock()
+    with patch(f"bot.main.adapter_client.{fetch_fn}", fetch_mock), patch.object(
+        main.bot, "get_channel", return_value=channel
+    ), patch.object(main.bot.scheduler, "add_job"), patch(
+        "bot.main.bot_bucket.acquire", AsyncMock()
+    ), patch("bot.main.bot_tokens.set"):
+        await main.poll_adapter(db, sub_id, data)
+    return channel
 
 
 def test_poll_adapter_dedupes_and_updates_cursor():
     db = storage.init_db("sqlite:///:memory:")
     sub_id = storage.add_subscription(db, 1, "events", "cities/1")
-    asyncio.run(run_poll(db, sub_id, [{"id": "1"}], {"interval": 60}))
-    asyncio.run(run_poll(db, sub_id, [{"id": "1"}], {"interval": 60}))
+    channel = asyncio.run(
+        run_poll(
+            db,
+            sub_id,
+            [{"id": "1", "title": "t", "link": "l", "time": "now"}],
+            {"interval": 60},
+            channel=AsyncMock(send=AsyncMock()),
+        )
+    )
+    asyncio.run(
+        run_poll(
+            db,
+            sub_id,
+            [{"id": "1", "title": "t", "link": "l", "time": "now"}],
+            {"interval": 60},
+            channel=channel,
+        )
+    )
     assert db.query(models.RelayLog).count() == 1
     _, ids = storage.get_cursor(db, sub_id)
     assert ids == ["1"]
+    assert channel.send.call_count == 1
 
 
 def test_poll_adapter_backoff_on_http_error():
@@ -41,7 +64,32 @@ def test_poll_adapter_backoff_on_http_error():
     ), patch.object(
         main.bot.scheduler,
         "add_job",
-    ) as add_job:
+    ) as add_job, patch(
+        "bot.main.bot_bucket.acquire", AsyncMock()
+    ), patch("bot.main.bot_tokens.set"):
         asyncio.run(main.poll_adapter(db, sub_id, data))
     assert data["backoff"] == 120
     add_job.assert_called_once()
+
+
+def test_poll_adapter_writings():
+    db = storage.init_db("sqlite:///:memory:")
+    sub_id = storage.add_subscription(db, 1, "writings", "1")
+    channel = asyncio.run(
+        run_poll(
+            db,
+            sub_id,
+            [
+                {
+                    "id": "1",
+                    "title": "t",
+                    "link": "l",
+                    "published": "now",
+                }
+            ],
+            {"interval": 60},
+            fetch_fn="fetch_writings",
+        )
+    )
+    assert db.query(models.RelayLog).count() == 1
+    channel.send.assert_called_once()

--- a/docs/decisions/2025-08-11.md
+++ b/docs/decisions/2025-08-11.md
@@ -8,3 +8,12 @@ Register cleanup of cookie files via `register_shutdown_function` and destructor
 
 ## Consequences
 Ensures no stale session files remain and provides regression coverage.
+
+## Context
+Polling previously only updated cursors without relaying content to Discord.
+
+## Decision
+Send Discord embeds for new events and writings, using subscription types to select adapter client helpers.
+
+## Consequences
+Provides richer notifications to channels but increases message throughput.

--- a/plan.md
+++ b/plan.md
@@ -1,15 +1,16 @@
 # Plan
 
 ## Goal
-Add asynchronous client helpers to fetch user writings and group posts from the adapter service.
+Relay new events and writings from the adapter as Discord embeds during polling.
 
 ## Constraints
-- Follow repository conventions including changelog, version bump, and tests.
-- Mirror existing aiohttp usage without introducing new dependencies.
+- Preserve existing dedupe, cursor, and metrics behavior.
+- Support both `events` and `writings` subscription types using adapter client helpers.
+- Follow repository conventions for changelog, version bump, and tests.
 
 ## Risks
-- Incorrect endpoint URLs could break polling.
-- Tests may need mocking to avoid network access.
+- Unexpected payload fields could render incomplete embeds.
+- Additional rate-limit calls may slow tests.
 
 ## Test Plan
 - `make check`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fetlife-discord-bot"
-version = "0.2.0"
+version = "0.3.0"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 classifiers = [


### PR DESCRIPTION
### Summary
- relay new events and writings to Discord channels using embeds
- add polling support for `writings` subscriptions

### SemVer
- [ ] patch (bugfix)
- [x] minor (backwards-compatible feature)
- [ ] major (breaking change)
Reason: adds new non-breaking capability for relaying content

### Checks
- [x] Updated version file(s)
- [x] Updated CHANGELOG.md
- [ ] Tests/CI green (make check missing docker)
- [x] AGENTS.md synced with reality


------
https://chatgpt.com/codex/tasks/task_e_6899e3359cf4833298c2dbde23fb37a9