### PR TITLE
test(writings): cover cursor update for writings subscription (v0.3.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+## [0.3.2] - 2025-08-11
+### Added
+- Test verifying writings subscription updates the cursor and sends a message.
+
 ## [0.3.1] - 2025-08-11
 ### Fixed
 - Constrain subscription type to events or writings, clarify target formats, and schedule polling with stored type.

--- a/bot/tests/test_writings_subscription.py
+++ b/bot/tests/test_writings_subscription.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from bot import main, storage  # noqa: E402
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+async def run_poll(db, sub_id: int, items: list[dict]):
+    channel = AsyncMock()
+    channel.send = AsyncMock()
+    with patch(
+        "bot.main.adapter_client.fetch_writings", AsyncMock(return_value=items)
+    ), patch.object(main.bot, "get_channel", return_value=channel), patch.object(
+        main.bot.scheduler, "add_job"
+    ), patch("bot.main.bot_bucket.acquire", AsyncMock()), patch(
+        "bot.main.bot_tokens.set"
+    ):
+        await main.poll_adapter(db, sub_id, {"interval": 60})
+    return channel
+
+
+def test_poll_writings_updates_cursor_and_sends_message():
+    db = storage.init_db("sqlite:///:memory:")
+    sub_id = storage.add_subscription(db, 1, "writings", "1")
+    item = json.loads((FIXTURES / "writing.json").read_text())
+    channel = asyncio.run(run_poll(db, sub_id, [item]))
+    channel.send.assert_called_once()
+    _, ids = storage.get_cursor(db, sub_id)
+    assert ids == [str(item["id"])]

--- a/plan.md
+++ b/plan.md
@@ -1,20 +1,19 @@
 # Plan
 
 ## Goal
-Constrain `/fl subscribe` to valid types and document target formats while scheduling polls using stored subscription types.
+Add a unit test covering writings subscriptions to ensure `poll_adapter` sends Discord messages and updates the cursor.
 
 ## Constraints
-- Use `discord.app_commands.choices` for `sub_type` limited to `events` or `writings`.
-- Update command descriptions and docstrings for `target` (`user:<nickname>` for writings, `location:<...>` for events).
-- When scheduling `poll_adapter`, pass the canonical `sub.type` from the database.
-- Maintain existing behavior for filters and metrics.
+- Mock `adapter_client.fetch_writings` to avoid network calls.
+- Reuse existing `bot/tests/fixtures/writing.json` for sample payload.
+- Patch Discord and scheduler interactions to keep the test self-contained.
 
 ## Risks
-- Direct invocation in tests may bypass decorator validation.
-- Fetching the stored subscription may fail if the database returns `None`.
+- Incorrect patching could leave background jobs running or unawaited coroutines.
+- Cursor assertions may fail if IDs are not coerced to strings.
 
 ## Test Plan
 - `make check`
 
 ## Semver
-Patch: bugfix and documentation.
+Patch: tests only.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fetlife-discord-bot"
-version = "0.3.1"
+version = "0.3.2"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 classifiers = [


### PR DESCRIPTION
### Summary
- add unit test ensuring `poll_adapter` sends Discord messages and updates the cursor for writings subscriptions
- bump version to v0.3.2 and update changelog

### SemVer
- [x] patch (bugfix)
- [ ] minor (backwards-compatible feature)
- [ ] major (breaking change)
Reason: tests only

### Checks
- [x] Updated version file(s)
- [x] Updated CHANGELOG.md
- [ ] Tests/CI green (Docker not installed; `make check` failed)
- [x] AGENTS.md synced with reality


------
https://chatgpt.com/codex/tasks/task_e_6899e8beecc483328eb1c9e51c772a45