### PR TITLE
feat(accounts): add multi-account support (v0.4.0)

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -18,6 +18,8 @@ Discord UX:
 
 Slash commands to subscribe/unsubscribe sources (users, groups, locations, events).
 
+Slash commands to add, list, or remove stored FetLife accounts and select one per subscription.
+
 Per-channel filters (location radius, keywords, content types, frequency).
 
 Rich embeds, optional attendee sampling, thread-per-event option.
@@ -60,7 +62,9 @@ guilds(id, name, created_at)
 
 channels(id, guild_id, name, created_at)
 
-subscriptions(id, channel_id, type, target_id, target_kind, filters_json, created_by, created_at, active)
+subscriptions(id, channel_id, type, target_id, target_kind, filters_json, created_by, created_at, active, account_id)
+
+accounts(id, username, credential_hash, created_at)
 
 type: events|writings|group_posts|attendees
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+## [0.4.0] - 2025-08-11
+### Added
+- Manage multiple FetLife accounts with `/fl account` subcommands and optional per-subscription selection.
+- Adapter and bot polling now isolate sessions per account via `X-Account-ID` header.
+- Database models and storage helpers for accounts with hashed credentials.
+- Tests covering account creation, selection, and multi-account polling.
+
 ## [0.3.2] - 2025-08-11
 ### Added
 - Test verifying writings subscription updates the cursor and sends a message.

--- a/bot/adapter_client.py
+++ b/bot/adapter_client.py
@@ -5,25 +5,53 @@ from typing import Any
 import aiohttp
 
 
-async def fetch_events(base_url: str, location: str) -> list[dict[str, Any]]:
+async def login(
+    base_url: str, username: str, password: str, account_id: int
+) -> dict[str, Any]:
+    async with aiohttp.ClientSession() as session:
+        async with session.post(
+            f"{base_url}/login",
+            json={"username": username, "password": password},
+            headers={"X-Account-ID": str(account_id)},
+        ) as resp:
+            resp.raise_for_status()
+            return await resp.json()
+
+
+async def fetch_events(
+    base_url: str, location: str, account_id: int | None = None
+) -> list[dict[str, Any]]:
     """Fetch events from the adapter service."""
+    headers = {"X-Account-ID": str(account_id)} if account_id is not None else {}
     async with aiohttp.ClientSession() as session:
-        async with session.get(f"{base_url}/events", params={"location": location}) as resp:
+        async with session.get(
+            f"{base_url}/events", params={"location": location}, headers=headers
+        ) as resp:
             resp.raise_for_status()
             return await resp.json()
 
 
-async def fetch_writings(base_url: str, user_id: str) -> list[dict[str, Any]]:
+async def fetch_writings(
+    base_url: str, user_id: str, account_id: int | None = None
+) -> list[dict[str, Any]]:
     """Fetch writings for a user from the adapter service."""
+    headers = {"X-Account-ID": str(account_id)} if account_id is not None else {}
     async with aiohttp.ClientSession() as session:
-        async with session.get(f"{base_url}/users/{user_id}/writings") as resp:
+        async with session.get(
+            f"{base_url}/users/{user_id}/writings", headers=headers
+        ) as resp:
             resp.raise_for_status()
             return await resp.json()
 
 
-async def fetch_group_posts(base_url: str, group_id: str) -> list[dict[str, Any]]:
+async def fetch_group_posts(
+    base_url: str, group_id: str, account_id: int | None = None
+) -> list[dict[str, Any]]:
     """Fetch posts for a group from the adapter service."""
+    headers = {"X-Account-ID": str(account_id)} if account_id is not None else {}
     async with aiohttp.ClientSession() as session:
-        async with session.get(f"{base_url}/groups/{group_id}/posts") as resp:
+        async with session.get(
+            f"{base_url}/groups/{group_id}/posts", headers=headers
+        ) as resp:
             resp.raise_for_status()
             return await resp.json()

--- a/bot/db.py
+++ b/bot/db.py
@@ -1,6 +1,7 @@
 import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import declarative_base, sessionmaker
+import hashlib
 
 
 def _build_url() -> str:
@@ -23,6 +24,10 @@ DATABASE_URL = _build_url()
 engine = create_engine(DATABASE_URL, future=True)
 SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
 Base = declarative_base()
+
+
+def hash_credentials(username: str, password: str) -> str:
+    return hashlib.sha256(f"{username}:{password}".encode()).hexdigest()
 
 def init_db(url: str | None = None):
     global engine, SessionLocal

--- a/bot/models.py
+++ b/bot/models.py
@@ -29,6 +29,14 @@ class Channel(Base):
     settings_json = Column(JSON, nullable=True)
 
 
+class Account(Base):
+    __tablename__ = "accounts"
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    username = Column(String, nullable=False)
+    credential_hash = Column(String, nullable=False, unique=True)
+    created_at = Column(DateTime, server_default=func.now(), nullable=False)
+
+
 class Subscription(Base):
     __tablename__ = "subscriptions"
     id = Column(Integer, primary_key=True, autoincrement=True)
@@ -40,6 +48,7 @@ class Subscription(Base):
     created_by = Column(BigInteger, nullable=True)
     created_at = Column(DateTime, server_default=func.now(), nullable=False)
     active = Column(Boolean, server_default="1", nullable=False)
+    account_id = Column(Integer, ForeignKey("accounts.id"), nullable=True)
 
 
 class Cursor(Base):

--- a/bot/tests/test_accounts.py
+++ b/bot/tests/test_accounts.py
@@ -1,0 +1,53 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from bot import storage, models, main
+
+
+def setup_db():
+    return storage.init_db("sqlite:///:memory:")
+
+
+def test_add_list_remove_account():
+    db = setup_db()
+    aid = storage.add_account(db, "u", "p")
+    accounts = list(storage.list_accounts(db))
+    assert accounts == [(aid, "u")]
+    storage.remove_account(db, aid)
+    assert list(storage.list_accounts(db)) == []
+
+
+def test_subscription_account_selection():
+    db = setup_db()
+    a1 = storage.add_account(db, "u1", "p1")
+    sub_id = storage.add_subscription(db, 1, "events", "t", account_id=a1)
+    sub = db.get(models.Subscription, sub_id)
+    assert sub.account_id == a1
+
+
+def test_poll_adapter_uses_correct_account():
+    db = setup_db()
+    a1 = storage.add_account(db, "u1", "p1")
+    a2 = storage.add_account(db, "u2", "p2")
+    s1 = storage.add_subscription(db, 1, "events", "loc1", account_id=a1)
+    s2 = storage.add_subscription(db, 1, "events", "loc2", account_id=a2)
+
+    channel = AsyncMock()
+    channel.send = AsyncMock()
+
+    fetch_mock = AsyncMock(return_value=[])
+    with patch("bot.main.adapter_client.fetch_events", fetch_mock), patch.object(
+        main.bot, "get_channel", return_value=channel
+    ), patch.object(main.bot.scheduler, "add_job"), patch(
+        "bot.main.bot_bucket.acquire", AsyncMock()
+    ), patch("bot.main.bot_tokens.set"):
+        asyncio.run(main.poll_adapter(db, s1, {"interval": 60}))
+        asyncio.run(main.poll_adapter(db, s2, {"interval": 60}))
+
+    assert fetch_mock.call_args_list[0].kwargs["account_id"] == a1
+    assert fetch_mock.call_args_list[1].kwargs["account_id"] == a2

--- a/bot/tests/test_adapter_client.py
+++ b/bot/tests/test_adapter_client.py
@@ -10,6 +10,7 @@ from bot.adapter_client import (
     fetch_events,
     fetch_group_posts,
     fetch_writings,
+    login,
 )
 
 
@@ -34,24 +35,33 @@ class DummySession:
     async def __aexit__(self, exc_type, exc, tb):
         pass
 
-    def get(self, url, params=None):
+    def get(self, url, params=None, headers=None):
+        return DummyResp()
+
+    def post(self, url, json=None, headers=None):
         return DummyResp()
 
 
 def test_fetch_events_mocked():
     with patch("aiohttp.ClientSession", return_value=DummySession()):
-        events = asyncio.run(fetch_events("http://adapter", "cities/1"))
+        events = asyncio.run(fetch_events("http://adapter", "cities/1", account_id=1))
     assert events == [{"id": 1}]
 
 
 def test_fetch_writings_mocked():
     with patch("aiohttp.ClientSession", return_value=DummySession()):
-        writings = asyncio.run(fetch_writings("http://adapter", "1"))
+        writings = asyncio.run(fetch_writings("http://adapter", "1", account_id=1))
     assert writings == [{"id": 1}]
 
 
 def test_fetch_group_posts_mocked():
     with patch("aiohttp.ClientSession", return_value=DummySession()):
-        posts = asyncio.run(fetch_group_posts("http://adapter", "1"))
+        posts = asyncio.run(fetch_group_posts("http://adapter", "1", account_id=1))
     assert posts == [{"id": 1}]
+
+
+def test_login_mocked():
+    with patch("aiohttp.ClientSession", return_value=DummySession()):
+        resp = asyncio.run(login("http://adapter", "u", "p", account_id=1))
+    assert resp == [{"id": 1}]
 

--- a/bot/tests/test_storage.py
+++ b/bot/tests/test_storage.py
@@ -1,6 +1,3 @@
-from pathlib import Path
-
-import os
 import sys
 from pathlib import Path
 
@@ -18,7 +15,7 @@ def test_add_and_list_subscription():
     db = setup_db()
     sub_id = storage.add_subscription(db, 1, "events", "target")
     subs = storage.list_subscriptions(db, 1)
-    assert subs == [(sub_id, "events", "target")]
+    assert subs == [(sub_id, "events", "target", None)]
 
 
 def test_remove_subscription():

--- a/docs/decisions/2025-08-11.md
+++ b/docs/decisions/2025-08-11.md
@@ -26,3 +26,12 @@ Limit `sub_type` to explicit choices and schedule `poll_adapter` with the stored
 
 ## Consequences
 Prevents invalid subscription types and ensures polling uses canonical values.
+
+## Context
+FetLife credentials were globally scoped, preventing per-subscription authentication and risking session crossover.
+
+## Decision
+Introduce an `accounts` table with hashed credentials, `/fl account` management commands, and adapter support for an `X-Account-ID` header to isolate sessions per account.
+
+## Consequences
+Subscriptions can use different FetLife accounts without sharing cookies, improving privacy and reducing cross-account interference.

--- a/plan.md
+++ b/plan.md
@@ -1,19 +1,20 @@
 # Plan
 
 ## Goal
-Add a unit test covering writings subscriptions to ensure `poll_adapter` sends Discord messages and updates the cursor.
+Support multiple FetLife accounts with per-subscription selection and session isolation.
 
 ## Constraints
-- Mock `adapter_client.fetch_writings` to avoid network calls.
-- Reuse existing `bot/tests/fixtures/writing.json` for sample payload.
-- Patch Discord and scheduler interactions to keep the test self-contained.
+- Preserve existing command structure; add `/fl account` subcommands and optional account selection for `/fl subscribe`.
+- Avoid storing plaintext credentials; persist only SHA-256 hashes.
+- Maintain backward compatibility for adapter requests without an explicit account ID.
 
 ## Risks
-- Incorrect patching could leave background jobs running or unawaited coroutines.
-- Cursor assertions may fail if IDs are not coerced to strings.
+- Incorrect session handling in the adapter could mix account cookies.
+- Added account_id parameter may break existing tests if not patched.
+- Hashing approach may not satisfy future security expectations.
 
 ## Test Plan
 - `make check`
 
 ## Semver
-Patch: tests only.
+Minor: new backwards-compatible feature set.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fetlife-discord-bot"
-version = "0.3.2"
+version = "0.4.0"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 classifiers = [


### PR DESCRIPTION
### Summary
- manage multiple FetLife accounts via `/fl account` commands and per-subscription selection
- isolate adapter sessions with `X-Account-ID` and hash credentials in new accounts table
- cover account creation and multi-account polling in tests

### SemVer
- [ ] patch (bugfix)
- [x] minor (backwards-compatible feature)
- [ ] major (breaking change)
Reason: adds new optional multi-account functionality without breaking existing flows.

### Checks
- [x] Updated version file(s)
- [x] Updated CHANGELOG.md
- [ ] Tests/CI green
- [x] AGENTS.md synced with reality


------
https://chatgpt.com/codex/tasks/task_e_689a1a542bfc83328132eb4c9112ad00