### PR TITLE
feat(bot): add group post subscriptions (v0.6.0)

### DIFF
--- a/.github/RELEASE_NOTES.md
+++ b/.github/RELEASE_NOTES.md
@@ -1,1 +1,4 @@
 <!-- Release notes will be compiled here for each tagged version. -->
+
+## v0.6.0
+- Add group post subscriptions with target validation and relay.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+## [0.6.0] - 2025-08-11
+### Added
+- Subscribe to group posts with `/fl subscribe group_posts group:<id>` and relay new posts.
+
 ## [0.5.0] - 2025-08-11
 ### Added
 - Adapter endpoint `/events/{id}/attendees` returning RSVP status and comments.

--- a/README.markdown
+++ b/README.markdown
@@ -11,7 +11,7 @@ The `bot/` directory contains a Python application using `discord.py` that relay
 1. `cp .env.example .env` and edit the file with your FetLife credentials, Discord token, and database settings.
 2. `docker compose up -d` to launch the adapter, bot, and database.
 3. `docker compose run --rm bot alembic upgrade head` to apply database migrations.
-4. Generate an invite link from the [Discord Developer Portal](https://discord.com/developers/applications), invite the bot to your server, then run `/fl login`, `/fl subscribe events location:cities/5898 min_attendees:10`, `/fl list`, and `/fl test <id>` in Discord.
+4. Generate an invite link from the [Discord Developer Portal](https://discord.com/developers/applications), invite the bot to your server, then run `/fl login`, `/fl subscribe events location:cities/5898 min_attendees:10`, `/fl subscribe group_posts group:1`, `/fl list`, and `/fl test <id>` in Discord.
 
 ### Environment Variables
 

--- a/bot/tests/test_group_posts_subscription.py
+++ b/bot/tests/test_group_posts_subscription.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import sys
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from bot import main, storage  # noqa: E402
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+@dataclass
+class DummyResponse:
+    message: str | None = None
+
+    async def send_message(self, content: str):
+        self.message = content
+
+
+@dataclass
+class DummyInteraction:
+    channel_id: int = 1
+    response: DummyResponse = field(default_factory=DummyResponse)
+
+
+async def run_poll(db, sub_id: int, items: list[dict]):
+    channel = AsyncMock()
+    channel.send = AsyncMock()
+    with patch(
+        "bot.main.adapter_client.fetch_group_posts", AsyncMock(return_value=items)
+    ), patch.object(main.bot, "get_channel", return_value=channel), patch.object(
+        main.bot.scheduler, "add_job"
+    ), patch("bot.main.bot_bucket.acquire", AsyncMock()), patch(
+        "bot.main.bot_tokens.set"
+    ):
+        await main.poll_adapter(db, sub_id, {"interval": 60})
+    return channel
+
+
+def test_fl_subscribe_group_posts_validates_target():
+    main.bot.db = storage.init_db("sqlite:///:memory:")
+    interaction = DummyInteraction()
+    # invalid target
+    with patch("bot.main.bot_bucket.acquire", AsyncMock()), patch(
+        "bot.main.bot_tokens.set"
+    ):
+        asyncio.run(
+            main.fl_subscribe.callback(interaction, "group_posts", "user:1")
+        )
+    assert interaction.response.message == "Target must be group:<id>"
+    interaction.response.message = None
+    with patch.object(main.bot.scheduler, "add_job") as add_job, patch(
+        "bot.main.bot_bucket.acquire", AsyncMock()
+    ), patch("bot.main.bot_tokens.set"):
+        asyncio.run(
+            main.fl_subscribe.callback(interaction, "group_posts", "group:1")
+        )
+        add_job.assert_called_once()
+
+
+def test_poll_group_posts_updates_cursor_and_dedupes():
+    db = storage.init_db("sqlite:///:memory:")
+    sub_id = storage.add_subscription(db, 1, "group_posts", "group:1")
+    item = json.loads((FIXTURES / "group_post.json").read_text())
+    channel = asyncio.run(run_poll(db, sub_id, [item]))
+    asyncio.run(run_poll(db, sub_id, [item]))
+    channel.send.assert_called_once()
+    _, ids = storage.get_cursor(db, sub_id)
+    assert ids == [str(item["id"])]

--- a/docs/decisions/2025-08-11.md
+++ b/docs/decisions/2025-08-11.md
@@ -44,3 +44,12 @@ Expose `/events/{id}/attendees` in the adapter and add bot support for an `atten
 
 ## Consequences
 Provides real-time awareness of who is going, maybe going, or not going to events, but increases adapter load when polling attendee lists.
+
+## Context
+Group discussions were not tracked, limiting subscription capabilities.
+
+## Decision
+Introduce a `group_posts` subscription type with target validation and polling that relays new group posts.
+
+## Consequences
+Channels can follow group posts but additional polling may increase adapter workload.

--- a/plan.md
+++ b/plan.md
@@ -1,16 +1,16 @@
 # Plan
 
 ## Goal
-Support attendee subscriptions by adding adapter endpoint `/events/{id}/attendees` and bot polling that relays attendee RSVP statuses and comments into Discord.
+Add group_posts subscriptions allowing the bot to poll the adapter for group posts and relay them, including target validation.
 
 ## Constraints
-- Keep existing adapter service patterns and reuse session/account handling.
-- Responses must include attendee `id`, `nickname`, `status`, and optional `comment`.
-- Maintain backward compatibility for existing event and writing subscriptions.
+- Support `sub_type="group_posts"` in `/fl subscribe`.
+- Require targets formatted as `group:<id>` where `<id>` is numeric.
+- Preserve existing event, writing, and attendee behavior.
 
 ## Risks
-- Parsing attendee lists may be slow and fail if HTML structure changes.
-- Schema or embed formatting errors could break polling.
+- Missing validation could allow malformed targets.
+- Embed formatting may omit published timestamps.
 
 ## Test Plan
 - `make check`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fetlife-discord-bot"
-version = "0.5.0"
+version = "0.6.0"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 classifiers = [


### PR DESCRIPTION
### Summary
- support `/fl subscribe group_posts group:<id>` with target validation
- poll adapter for group posts and relay embeds with published time
- document group post subscriptions

### SemVer
- [ ] patch (bugfix)
- [x] minor (backwards-compatible feature)
- [ ] major (breaking change)
Reason: Adds new non-breaking subscription type.

### Checks
- [x] Updated version file(s)
- [x] Updated CHANGELOG.md
- [ ] Tests/CI green (see notes: docker unavailable for `make check`)
- [x] AGENTS.md synced with reality


------
https://chatgpt.com/codex/tasks/task_e_689a210a68088332847b134c93b97a42