### PR TITLE
fix(login): verify adapter authentication (v0.7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+## [0.7.1] - 2025-08-11
+### Fixed
+- `/fl login` now verifies adapter authentication and reports failures.
+
 ## [0.7.0] - 2025-08-11
 ### Added
 - Relay Telegram chats into Discord with a Telethon bridge and `/fl telegram` commands.

--- a/README.markdown
+++ b/README.markdown
@@ -11,7 +11,7 @@ The `bot/` directory contains a Python application using `discord.py` that relay
 1. `cp .env.example .env` and edit the file with your FetLife credentials, Discord token, and database settings.
 2. `docker compose up -d` to launch the adapter, bot, and database.
 3. `docker compose run --rm bot alembic upgrade head` to apply database migrations.
-4. Generate an invite link from the [Discord Developer Portal](https://discord.com/developers/applications), invite the bot to your server, then run `/fl login`, `/fl subscribe events location:cities/5898 min_attendees:10`, `/fl subscribe group_posts group:1`, `/fl list`, and `/fl test <id>` in Discord.
+4. Generate an invite link from the [Discord Developer Portal](https://discord.com/developers/applications), invite the bot to your server, then run `/fl login` to verify adapter authentication, `/fl subscribe events location:cities/5898 min_attendees:10`, `/fl subscribe group_posts group:1`, `/fl list`, and `/fl test <id>` in Discord.
 
 ### Environment Variables
 

--- a/bot/adapter_client.py
+++ b/bot/adapter_client.py
@@ -5,6 +5,13 @@ from typing import Any
 import aiohttp
 
 
+async def login_adapter(base_url: str) -> bool:
+    """Log into the adapter using its configured credentials."""
+    async with aiohttp.ClientSession() as session:
+        async with session.post(f"{base_url}/login") as resp:
+            return resp.status == 200
+
+
 async def login(
     base_url: str, username: str, password: str, account_id: int
 ) -> dict[str, Any]:

--- a/bot/main.py
+++ b/bot/main.py
@@ -200,9 +200,14 @@ async def on_ready() -> None:
 
 @fl_group.command(name="login", description="Validate adapter service connectivity")
 async def fl_login(interaction: discord.Interaction) -> None:
+    try:
+        ok = await adapter_client.login_adapter(ADAPTER_BASE_URL)
+        msg = "Adapter login successful" if ok else "Adapter login failed"
+    except ClientError as exc:  # pragma: no cover - network error path
+        msg = f"Adapter login failed: {exc}"
     await bot_bucket.acquire()
     bot_tokens.set(bot_bucket.get_tokens())
-    await interaction.response.send_message("Adapter login successful")
+    await interaction.response.send_message(msg)
 
 
 @account_group.command(name="add", description="Add a FetLife account")

--- a/bot/tests/test_login_command.py
+++ b/bot/tests/test_login_command.py
@@ -1,0 +1,24 @@
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+from bot import main
+
+
+def test_fl_login_success():
+    interaction = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+    with patch("bot.main.adapter_client.login_adapter", AsyncMock(return_value=True)), \
+         patch("bot.main.bot_bucket.acquire", AsyncMock()), \
+         patch("bot.main.bot_tokens.set"):
+        asyncio.run(main.fl_login(interaction))
+    interaction.response.send_message.assert_called_once_with("Adapter login successful")
+
+
+def test_fl_login_failure():
+    interaction = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+    with patch("bot.main.adapter_client.login_adapter", AsyncMock(return_value=False)), \
+         patch("bot.main.bot_bucket.acquire", AsyncMock()), \
+         patch("bot.main.bot_tokens.set"):
+        asyncio.run(main.fl_login(interaction))
+    interaction.response.send_message.assert_called_once_with("Adapter login failed")

--- a/docs/decisions/2025-08-13.md
+++ b/docs/decisions/2025-08-13.md
@@ -1,0 +1,4 @@
+# 2025-08-13
+
+## Added
+- Introduced `login_adapter` helper and wired `/fl login` to verify adapter authentication with user feedback.

--- a/plan.md
+++ b/plan.md
@@ -1,20 +1,19 @@
 # Plan
 
 ## Goal
-Relay messages from specified Telegram chats into Discord channels with runtime mapping commands.
+Implement adapter authentication verification via `/fl login` command using a new helper.
 
 ## Constraints
-- Use Telethon for Telegram client functionality.
-- Maintain chat-to-channel mappings in `config.yaml`.
-- Provide `/fl telegram add|remove` commands for runtime management.
-- Integrate bridge startup/shutdown with existing bot process.
+- Use aiohttp for HTTP requests.
+- Follow existing command structure and metrics rate limiting.
+- Maintain documentation and tests in sync with behavior.
 
 ## Risks
-- Misconfigured mappings could relay to incorrect channels.
-- Telethon client failures may block shutdown.
+- Network errors during adapter login could produce unclear user feedback.
+- Misreported status if adapter returns unexpected codes.
 
 ## Test Plan
 - `make check`
 
 ## Semver
-Minor: new backwards-compatible feature.
+Patch: fixes `/fl login` to verify adapter authentication.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fetlife-discord-bot"
-version = "0.7.0"
+version = "0.7.1"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 classifiers = [


### PR DESCRIPTION
### Summary
- add `login_adapter` helper to POST `/login` and check status
- call helper in `/fl login` command to report authentication success or failure
- document `/fl login` adapter authentication check
- test command handling of successful and failed adapter responses

### SemVer
- [x] patch (bugfix)
- [ ] minor (backwards-compatible feature)
- [ ] major (breaking change)
Reason: fixes existing `/fl login` command to verify adapter authentication.

### Checks
- [x] Updated version file(s)
- [x] Updated CHANGELOG.md
- [ ] Tests/CI green (Docker daemon unavailable for `make check`)
- [x] AGENTS.md synced with reality

------
https://chatgpt.com/codex/tasks/task_e_689a2bb647e48332987415b48cdfa95b