### PR TITLE
feat(setup): add interactive setup script (v0.8.0)

### DIFF
--- a/.github/RELEASE_NOTES.md
+++ b/.github/RELEASE_NOTES.md
@@ -1,4 +1,8 @@
 <!-- Release notes will be compiled here for each tagged version. -->
 
+## v0.8.0
+- Add interactive setup script for environment configuration and migrations.
+
+
 ## v0.6.0
 - Add group post subscriptions with target validation and relay.

--- a/Agents.md
+++ b/Agents.md
@@ -205,6 +205,7 @@ Returns JSON to stdout.
 Both should normalize output (UTC timestamps, stable IDs, minimal PII, direct permalink).
 
 9) Configuration
+Run `scripts/setup.sh` to interactively create `.env`, optionally scaffold `config.yaml`, run `alembic upgrade head`, and start the bot (Ctrl-C to stop).
 .env
 
 makefile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+## [0.8.0] - 2025-08-11
+### Added
+- Interactive setup script for environment configuration, migrations, and bot startup.
+
 ## [0.7.1] - 2025-08-11
 ### Fixed
 - `/fl login` now verifies adapter authentication and reports failures.

--- a/plan.md
+++ b/plan.md
@@ -1,19 +1,20 @@
 # Plan
 
 ## Goal
-Implement adapter authentication verification via `/fl login` command using a new helper.
+Provide an interactive setup script that writes required environment variables, applies database migrations, and launches the bot. Update documentation to reference the new script.
 
 ## Constraints
-- Use aiohttp for HTTP requests.
-- Follow existing command structure and metrics rate limiting.
-- Maintain documentation and tests in sync with behavior.
+- Bash script must skip existing `.env` entries.
+- Support optional creation of `config.yaml`.
+- Adhere to repository release and documentation conventions.
 
 ## Risks
-- Network errors during adapter login could produce unclear user feedback.
-- Misreported status if adapter returns unexpected codes.
+- Script may fail if dependencies like Alembic or Docker are missing.
+- Writing to existing files could overwrite user configuration.
 
 ## Test Plan
+- `bash scripts/agents-verify.sh`
 - `make check`
 
 ## Semver
-Patch: fixes `/fl login` to verify adapter authentication.
+Minor: adds a new setup feature.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fetlife-discord-bot"
-version = "0.7.1"
+version = "0.8.0"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 classifiers = [

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENV_FILE=".env"
+
+prompt() {
+  local msg="$1" default="${2-}"
+  local val
+  read -r -p "$msg" val
+  if [[ -z "$val" && -n "$default" ]]; then
+    val="$default"
+  fi
+  printf '%s' "$val"
+}
+
+write_env() {
+  local key="$1" value="$2"
+  if [[ -f "$ENV_FILE" ]] && grep -q "^${key}=" "$ENV_FILE"; then
+    echo "$key already set in $ENV_FILE; skipping."
+  else
+    echo "$key=$value" >> "$ENV_FILE"
+  fi
+}
+
+# Ensure .env exists
+if [[ ! -f "$ENV_FILE" ]]; then
+  touch "$ENV_FILE"
+  echo "Created $ENV_FILE"
+fi
+
+# Gather credentials and DB parameters
+FETLIFE_USERNAME=$(prompt "FETLIFE_USERNAME: ")
+FETLIFE_PASSWORD=$(prompt "FETLIFE_PASSWORD: ")
+DISCORD_TOKEN=$(prompt "DISCORD_TOKEN: ")
+DB_HOST=$(prompt "DB_HOST [localhost]: " "localhost")
+DB_PORT=$(prompt "DB_PORT [5432]: " "5432")
+DB_NAME=$(prompt "DB_NAME [bot]: " "bot")
+DB_USER=$(prompt "DB_USER [bot]: " "bot")
+DB_PASSWORD=$(prompt "DB_PASSWORD: ")
+
+write_env FETLIFE_USERNAME "$FETLIFE_USERNAME"
+write_env FETLIFE_PASSWORD "$FETLIFE_PASSWORD"
+write_env DISCORD_TOKEN "$DISCORD_TOKEN"
+write_env DB_HOST "$DB_HOST"
+write_env DB_PORT "$DB_PORT"
+write_env DB_NAME "$DB_NAME"
+write_env DB_USER "$DB_USER"
+write_env DB_PASSWORD "$DB_PASSWORD"
+
+# Optionally create config.yaml
+read -r -p "Create config.yaml? (y/N): " cfg
+if [[ "$cfg" =~ ^[Yy]$ ]]; then
+  if [[ -f "config.yaml" ]]; then
+    echo "config.yaml already exists; leaving as is."
+  else
+    cat > config.yaml <<'EOC'
+# Default settings applied to all channels
+defaults:
+  thread_per_event: false
+EOC
+    echo "Wrote config.yaml"
+  fi
+fi
+
+# Export environment
+set -a
+source "$ENV_FILE"
+set +a
+
+echo "Applying database migrations..."
+alembic upgrade head
+
+trap 'echo "Interrupt received, shutting down..."; kill $BOT_PID 2>/dev/null; wait $BOT_PID 2>/dev/null; exit 0' INT
+
+echo "Starting bot. Press Ctrl-C to stop."
+python bot/main.py &
+BOT_PID=$!
+wait $BOT_PID


### PR DESCRIPTION
### Summary
- add `scripts/setup.sh` to prompt for credentials, write `.env`, run migrations, and start the bot
- document setup script in AGENTS.md and update release notes
- bump version to v0.8.0

### Rationale
- streamline local configuration and onboarding

### SemVer
- [ ] patch (bugfix)
- [x] minor (backwards-compatible feature)
- [ ] major (breaking change)
Reason: adds a new setup utility without altering existing behavior.

### Checks
- [x] Updated version file(s)
- [x] Updated CHANGELOG.md
- [ ] Tests/CI green (docker not installed for `make check`)
- [x] AGENTS.md synced with reality
- [x] A: repo intake
- [x] B: plan.md updated
- [x] C: implementation complete
- [x] D: release notes and version bumped
- [ ] E: validation attempted (`make check` failed; see notes)
- [x] F: documentation updated


------
https://chatgpt.com/codex/tasks/task_e_689a55bd11c483328494d70c7da284ce