### PR TITLE
docs: document 24/7 remote server operation (v0.8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+### Added
+- Instructions for running the bot 24/7 on a remote server using Docker Compose or systemd.
+
 ## [0.8.0] - 2025-08-11
 ### Added
 - Interactive setup script for environment configuration, migrations, and bot startup.

--- a/README.markdown
+++ b/README.markdown
@@ -80,6 +80,59 @@ cd bot
 python main.py
 ```
 
+### Running 24/7 on a Remote Server
+
+For unattended deployments run [`scripts/setup.sh`](scripts/setup.sh) once to generate the `.env`, apply migrations, and perform initial configuration.
+
+#### Docker Compose
+
+Ensure `restart: unless-stopped` is set in `docker-compose.yml` and launch the stack in the background:
+
+```bash
+docker compose up -d
+```
+
+Docker stores logs per container; view them with:
+
+```bash
+docker compose logs -f bot
+```
+
+#### systemd service
+
+Create `/etc/systemd/system/fetlife-bot.service`:
+
+```ini
+[Unit]
+Description=FetLife Discord Bot
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=/opt/fetlife-discord-bot
+ExecStart=/usr/bin/python /opt/fetlife-discord-bot/bot/main.py
+Restart=on-failure
+EnvironmentFile=/opt/fetlife-discord-bot/.env
+StandardOutput=append:/var/log/fetlife-bot.log
+StandardError=append:/var/log/fetlife-bot.log
+
+[Install]
+WantedBy=multi-user.target
+```
+
+Enable and start the service:
+
+```bash
+sudo systemctl enable --now fetlife-bot.service
+```
+
+View status and logs:
+
+```bash
+systemctl status fetlife-bot.service
+journalctl -u fetlife-bot.service -f
+```
+
 ## System requirements
 
 To run `libFetLife`, you need PHP version 5.3.6 or greater (with [PHP's cURL extension](https://php.net/manual/book.curl.php) installed).

--- a/plan.md
+++ b/plan.md
@@ -1,20 +1,21 @@
 # Plan
 
 ## Goal
-Provide an interactive setup script that writes required environment variables, applies database migrations, and launches the bot. Update documentation to reference the new script.
+Document how to run the bot 24/7 on a remote server in README.
 
 ## Constraints
-- Bash script must skip existing `.env` entries.
-- Support optional creation of `config.yaml`.
-- Adhere to repository release and documentation conventions.
+- Include Docker Compose and systemd options.
+- Reference `scripts/setup.sh` for initial configuration.
+- Mention log locations and service status commands.
+- Follow repository documentation and release conventions.
 
 ## Risks
-- Script may fail if dependencies like Alembic or Docker are missing.
-- Writing to existing files could overwrite user configuration.
+- `systemd` paths differ across distributions.
+- Inaccurate log paths could mislead users.
 
 ## Test Plan
 - `bash scripts/agents-verify.sh`
 - `make check`
 
 ## Semver
-Minor: adds a new setup feature.
+Patch: documentation-only change.


### PR DESCRIPTION
### Summary
- add README section on running the bot 24/7 via Docker Compose or systemd
- note log access commands and reference setup script

### SemVer
- patch (documentation only)

### Checks
- [ ] Updated version file(s) *(n/a)*
- [x] Updated CHANGELOG.md
- [ ] Tests/CI green *(make check failed: `docker: 'compose' is not a docker command`)*
- [x] AGENTS.md synced with reality

------
https://chatgpt.com/codex/tasks/task_e_689a575ca3e48332ab7846301363adbf