### PR TITLE
fix(bot): run as module (v0.8.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+## [0.8.1] - 2025-08-11
 ### Added
 - Instructions for running the bot 24/7 on a remote server using Docker Compose or systemd.
+### Changed
+- Run bot as a module via `python -m bot.main` in Docker and documentation.
 
 ## [0.8.0] - 2025-08-11
 ### Added

--- a/README.markdown
+++ b/README.markdown
@@ -76,8 +76,7 @@ docker compose run --rm bot alembic upgrade head
 Run the bot with:
 
 ```bash
-cd bot
-python main.py
+python -m bot.main
 ```
 
 ### Running 24/7 on a Remote Server
@@ -110,7 +109,7 @@ After=network.target
 [Service]
 Type=simple
 WorkingDirectory=/opt/fetlife-discord-bot
-ExecStart=/usr/bin/python /opt/fetlife-discord-bot/bot/main.py
+ExecStart=/usr/bin/python -m bot.main
 Restart=on-failure
 EnvironmentFile=/opt/fetlife-discord-bot/.env
 StandardOutput=append:/var/log/fetlife-bot.log

--- a/bot/Dockerfile
+++ b/bot/Dockerfile
@@ -15,4 +15,4 @@ RUN pip3 install --no-cache-dir -r requirements.txt \
 COPY bot/ bot/
 
 EXPOSE 3000
-CMD ["python3", "bot/main.py"]
+CMD ["python3", "-m", "bot.main"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     depends_on:
       - adapter
       - db
-    command: ["python3", "bot/main.py"]
+    command: ["python3", "-m", "bot.main"]
     restart: unless-stopped
 
 volumes:

--- a/docs/decisions/2025-08-14.md
+++ b/docs/decisions/2025-08-14.md
@@ -1,0 +1,10 @@
+# 2025-08-14
+
+## Decision
+Switch bot execution to `python -m bot.main` instead of invoking the file path.
+
+## Context
+Running the bot as a module ensures the package is resolved relative to the project root and avoids path issues in containers and scripts.
+
+## Consequences
+All documentation and tooling now reference `python -m bot.main`; developers and Docker images must use the module form.

--- a/plan.md
+++ b/plan.md
@@ -1,21 +1,30 @@
 # Plan
 
+## Repo Intake
+- Languages: Python, PHP.
+- Build tools: setuptools via `pyproject.toml`, Composer for PHP.
+- Package managers: pip (requirements.txt), Composer.
+- Test commands: `make check` (lint, unit tests, integration tests) and `bash scripts/agents-verify.sh`.
+- Entry points: `python -m bot.main` for the bot, adapter service via PHP.
+- CI jobs: `release-hygiene.yml` (make check, version/changelog verification, agents drift check) and `release.yml` (tags and notes).
+- Release process: bump version in `pyproject.toml`, update `CHANGELOG.md`, tag `vX.Y.Z` on main.
+
 ## Goal
-Document how to run the bot 24/7 on a remote server in README.
+Switch bot execution to module invocation and update all references from `python bot/main.py` to `python -m bot.main`.
 
 ## Constraints
-- Include Docker Compose and systemd options.
-- Reference `scripts/setup.sh` for initial configuration.
-- Mention log locations and service status commands.
-- Follow repository documentation and release conventions.
+- Update `docker-compose.yml`, `bot/Dockerfile`, `scripts/setup.sh`, and documentation.
+- Preserve commit conventions and run repository checks.
+- Bump patch version and changelog.
 
 ## Risks
-- `systemd` paths differ across distributions.
-- Inaccurate log paths could mislead users.
+- Missing environment variables may cause startup failure when verifying.
+- Potential overlooked references to old command.
 
 ## Test Plan
 - `bash scripts/agents-verify.sh`
 - `make check`
+- `python -m bot.main` (expect failure without token but confirms entry point)
 
 ## Semver
-Patch: documentation-only change.
+Patch: command and documentation adjustments only.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fetlife-discord-bot"
-version = "0.8.0"
+version = "0.8.1"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 classifiers = [

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -73,6 +73,6 @@ alembic upgrade head
 trap 'echo "Interrupt received, shutting down..."; kill $BOT_PID 2>/dev/null; wait $BOT_PID 2>/dev/null; exit 0' INT
 
 echo "Starting bot. Press Ctrl-C to stop."
-python bot/main.py &
+python -m bot.main &
 BOT_PID=$!
 wait $BOT_PID


### PR DESCRIPTION
### Summary
- run the bot using `python -m bot.main` in Docker and local scripts
- document module-based invocation and systemd ExecStart
- bump to version 0.8.1

### Rationale
- module invocation avoids path issues and aligns with Python packaging

### Test Plan
- `bash scripts/agents-verify.sh`
- `make check` *(fails: `docker: 'compose' is not a docker command`)*
- `DISCORD_TOKEN=fake TELEGRAM_API_ID=123 TELEGRAM_API_HASH=abc python -m bot.main` *(fails to connect to Telegram but entrypoint executes)*

### SemVer
- [x] patch
- [ ] minor
- [ ] major
Reason: command and documentation updates

### Checklist
- [x] Updated version file(s)
- [x] Updated CHANGELOG.md
- [ ] Tests/CI green
- [x] AGENTS.md synced with reality


------
https://chatgpt.com/codex/tasks/task_e_689a63d9a7bc8332b402263e252a58aa