### PR TITLE
build: configure black formatting (v0.8.2)

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -356,7 +356,7 @@ One feature per PR; include tests and docs updates.
 
 No secrets in code or logs.
 
-Run make check (lint, tests, schema) before PR.
+Run `make fmt` for Black formatting and `make check` (formatting check, lint, tests, schema) before PR.
 
 Follow semantic commits and Conventional Changelog.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+## [0.8.2] - 2025-08-11
+### Added
+- Black code formatting configuration and `make fmt` target.
+### Changed
+- `make check` now runs `black --check`.
+
 ## [0.8.1] - 2025-08-11
 ### Added
 - Instructions for running the bot 24/7 on a remote server using Docker Compose or systemd.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
-.PHONY: check
+.PHONY: check fmt
+
+fmt:
+	docker compose run --rm bot black bot
 
 check:
 	docker compose build
+	docker compose run --rm bot black --check bot
 	docker compose run --rm bot flake8 bot
 	docker compose run --rm bot pytest
 	docker compose -f tests/docker-compose.test.yml build

--- a/bot/config.py
+++ b/bot/config.py
@@ -27,7 +27,9 @@ def save_config(config: Dict[str, Any], path: str = "config.yaml") -> None:
         yaml.safe_dump(config, f)
 
 
-def get_channel_config(config: Dict[str, Any], guild_id: int | None, channel_id: int) -> Dict[str, Any]:
+def get_channel_config(
+    config: Dict[str, Any], guild_id: int | None, channel_id: int
+) -> Dict[str, Any]:
     settings: Dict[str, Any] = {}
     if not config:
         return settings

--- a/bot/db.py
+++ b/bot/db.py
@@ -29,6 +29,7 @@ Base = declarative_base()
 def hash_credentials(username: str, password: str) -> str:
     return hashlib.sha256(f"{username}:{password}".encode()).hexdigest()
 
+
 def init_db(url: str | None = None):
     global engine, SessionLocal
     if url:

--- a/bot/main.py
+++ b/bot/main.py
@@ -74,8 +74,6 @@ telegram_group = app_commands.Group(
 )
 
 
-
-
 async def poll_adapter(db, sub_id: int, data: Dict[str, Any]):
     """Poll adapter with jitter and backoff, caching cursor and deduping."""
     start = time.perf_counter()
@@ -130,7 +128,9 @@ async def poll_adapter(db, sub_id: int, data: Dict[str, Any]):
                     )
                     if sub.type == "events" and item.get("time"):
                         embed.add_field(name="Start", value=item["time"])
-                    if sub.type in ("writings", "group_posts") and item.get("published"):
+                    if sub.type in ("writings", "group_posts") and item.get(
+                        "published"
+                    ):
                         embed.add_field(name="Published", value=item["published"])
                 await bot_bucket.acquire()
                 bot_tokens.set(bot_bucket.get_tokens())
@@ -215,9 +215,7 @@ async def fl_account_add(
     interaction: discord.Interaction, username: str, password: str
 ) -> None:
     acct_id = storage.add_account(bot.db, username, password)
-    await adapter_client.login(
-        ADAPTER_BASE_URL, username, password, account_id=acct_id
-    )
+    await adapter_client.login(ADAPTER_BASE_URL, username, password, account_id=acct_id)
     await bot_bucket.acquire()
     bot_tokens.set(bot_bucket.get_tokens())
     await interaction.response.send_message(f"Account {acct_id} added")
@@ -261,9 +259,7 @@ async def fl_telegram_add(
 
 
 @telegram_group.command(name="remove", description="Stop relaying a Telegram chat")
-async def fl_telegram_remove(
-    interaction: discord.Interaction, chat_id: str
-) -> None:
+async def fl_telegram_remove(interaction: discord.Interaction, chat_id: str) -> None:
     bot.bridge.remove_mapping(int(chat_id))
     bot.config.get("telegram_bridge", {}).get("mappings", {}).pop(str(chat_id), None)
     save_config(bot.config)
@@ -305,9 +301,7 @@ async def fl_subscribe(
         except json.JSONDecodeError:
             await bot_bucket.acquire()
             bot_tokens.set(bot_bucket.get_tokens())
-            await interaction.response.send_message(
-                "Invalid JSON for filters"
-            )
+            await interaction.response.send_message("Invalid JSON for filters")
             return
     else:
         filters_json = {}
@@ -343,9 +337,7 @@ async def fl_list(interaction: discord.Interaction) -> None:
         bot_tokens.set(bot_bucket.get_tokens())
         await interaction.response.send_message("No subscriptions")
         return
-    desc = "\n".join(
-        f"`{sid}` {typ} {tgt} (acct {aid})" for sid, typ, tgt, aid in subs
-    )
+    desc = "\n".join(f"`{sid}` {typ} {tgt} (acct {aid})" for sid, typ, tgt, aid in subs)
     embed = discord.Embed(title="Subscriptions", description=desc)
     await bot_bucket.acquire()
     bot_tokens.set(bot_bucket.get_tokens())
@@ -369,7 +361,7 @@ async def fl_test(interaction: discord.Interaction, sub_id: int) -> None:
     embed = discord.Embed(title="Test Notification", description=f"sub {sub_id}")
     await bot_bucket.acquire()
     bot_tokens.set(bot_bucket.get_tokens())
-    msg = await interaction.response.send_message(embed=embed)
+    await interaction.response.send_message(embed=embed)
     messages_sent.inc()
     db_settings = storage.get_channel_settings(bot.db, interaction.channel_id)
     cfg = get_channel_config(bot.config, interaction.guild_id, interaction.channel_id)
@@ -391,7 +383,9 @@ async def fl_settings(
         await interaction.response.send_message("Updated settings")
     else:
         db_settings = storage.get_channel_settings(bot.db, interaction.channel_id)
-        cfg = get_channel_config(bot.config, interaction.guild_id, interaction.channel_id)
+        cfg = get_channel_config(
+            bot.config, interaction.guild_id, interaction.channel_id
+        )
         settings = {**db_settings, **cfg}
         await bot_bucket.acquire()
         bot_tokens.set(bot_bucket.get_tokens())
@@ -408,9 +402,7 @@ async def fl_health(interaction: discord.Interaction) -> None:
     )
     await bot_bucket.acquire()
     bot_tokens.set(bot_bucket.get_tokens())
-    await interaction.response.send_message(
-        f"last_poll: {last}; queue_depth: {depth}"
-    )
+    await interaction.response.send_message(f"last_poll: {last}; queue_depth: {depth}")
 
 
 @fl_group.command(name="purge", description="Purge local caches")

--- a/bot/models.py
+++ b/bot/models.py
@@ -56,7 +56,9 @@ class Cursor(Base):
     subscription_id = Column(Integer, ForeignKey("subscriptions.id"), primary_key=True)
     last_seen_at = Column(DateTime, nullable=True)
     last_item_ids_json = Column(JSON, nullable=True)
-    updated_at = Column(DateTime, server_default=func.now(), onupdate=func.now(), nullable=False)
+    updated_at = Column(
+        DateTime, server_default=func.now(), onupdate=func.now(), nullable=False
+    )
 
 
 class RelayLog(Base):

--- a/bot/rate_limit.py
+++ b/bot/rate_limit.py
@@ -1,6 +1,7 @@
 import asyncio
 import time
 
+
 class TokenBucket:
     """Asynchronous token bucket rate limiter."""
 

--- a/bot/storage.py
+++ b/bot/storage.py
@@ -128,12 +128,19 @@ def update_cursor(
 def has_relayed(db: Session, sub_id: int, item_id: str) -> bool:
     return (
         db.query(models.RelayLog)
-        .filter(models.RelayLog.subscription_id == sub_id, models.RelayLog.item_id == item_id)
+        .filter(
+            models.RelayLog.subscription_id == sub_id,
+            models.RelayLog.item_id == item_id,
+        )
         .first()
         is not None
     )
 
 
-def record_relay(db: Session, sub_id: int, item_id: str, item_hash: str | None = None) -> None:
-    db.add(models.RelayLog(subscription_id=sub_id, item_id=item_id, item_hash=item_hash))
+def record_relay(
+    db: Session, sub_id: int, item_id: str, item_hash: str | None = None
+) -> None:
+    db.add(
+        models.RelayLog(subscription_id=sub_id, item_id=item_id, item_hash=item_hash)
+    )
     db.commit()

--- a/bot/telegram_bridge.py
+++ b/bot/telegram_bridge.py
@@ -24,8 +24,8 @@ class TelegramBridge:
         if config is None:
             config = load_config(config_path)
         self.config = config
-        self.mappings: Dict[str, str] = (
-            config.get("telegram_bridge", {}).get("mappings", {})
+        self.mappings: Dict[str, str] = config.get("telegram_bridge", {}).get(
+            "mappings", {}
         )
 
     async def start(self) -> None:

--- a/bot/tests/test_accounts.py
+++ b/bot/tests/test_accounts.py
@@ -41,11 +41,13 @@ def test_poll_adapter_uses_correct_account():
     channel.send = AsyncMock()
 
     fetch_mock = AsyncMock(return_value=[])
-    with patch("bot.main.adapter_client.fetch_events", fetch_mock), patch.object(
-        main.bot, "get_channel", return_value=channel
-    ), patch.object(main.bot.scheduler, "add_job"), patch(
-        "bot.main.bot_bucket.acquire", AsyncMock()
-    ), patch("bot.main.bot_tokens.set"):
+    with (
+        patch("bot.main.adapter_client.fetch_events", fetch_mock),
+        patch.object(main.bot, "get_channel", return_value=channel),
+        patch.object(main.bot.scheduler, "add_job"),
+        patch("bot.main.bot_bucket.acquire", AsyncMock()),
+        patch("bot.main.bot_tokens.set"),
+    ):
         asyncio.run(main.poll_adapter(db, s1, {"interval": 60}))
         asyncio.run(main.poll_adapter(db, s2, {"interval": 60}))
 

--- a/bot/tests/test_adapter_client.py
+++ b/bot/tests/test_adapter_client.py
@@ -71,4 +71,3 @@ def test_login_mocked():
     with patch("aiohttp.ClientSession", return_value=DummySession()):
         resp = asyncio.run(login("http://adapter", "u", "p", account_id=1))
     assert resp == [{"id": 1}]
-

--- a/bot/tests/test_attendees_subscription.py
+++ b/bot/tests/test_attendees_subscription.py
@@ -16,12 +16,12 @@ FIXTURES = Path(__file__).parent / "fixtures"
 async def run_poll(db, sub_id: int, items: list[dict]):
     channel = AsyncMock()
     channel.send = AsyncMock()
-    with patch(
-        "bot.main.adapter_client.fetch_attendees", AsyncMock(return_value=items)
-    ), patch.object(main.bot, "get_channel", return_value=channel), patch.object(
-        main.bot.scheduler, "add_job"
-    ), patch("bot.main.bot_bucket.acquire", AsyncMock()), patch(
-        "bot.main.bot_tokens.set"
+    with (
+        patch("bot.main.adapter_client.fetch_attendees", AsyncMock(return_value=items)),
+        patch.object(main.bot, "get_channel", return_value=channel),
+        patch.object(main.bot.scheduler, "add_job"),
+        patch("bot.main.bot_bucket.acquire", AsyncMock()),
+        patch("bot.main.bot_tokens.set"),
     ):
         await main.poll_adapter(db, sub_id, {"interval": 60})
     return channel

--- a/bot/tests/test_invalid_json.py
+++ b/bot/tests/test_invalid_json.py
@@ -24,7 +24,9 @@ def test_fl_subscribe_invalid_json():
         main.bot.db = storage.init_db("sqlite:///:memory:")
         interaction = DummyInteraction()
         with patch.object(main.bot.scheduler, "add_job") as add_job:
-            await main.fl_subscribe.callback(interaction, "events", "cities/1", filters="{bad")
+            await main.fl_subscribe.callback(
+                interaction, "events", "cities/1", filters="{bad"
+            )
             add_job.assert_not_called()
         return interaction
 

--- a/bot/tests/test_login_command.py
+++ b/bot/tests/test_login_command.py
@@ -7,18 +7,24 @@ from bot import main
 def test_fl_login_success():
     interaction = AsyncMock()
     interaction.response.send_message = AsyncMock()
-    with patch("bot.main.adapter_client.login_adapter", AsyncMock(return_value=True)), \
-         patch("bot.main.bot_bucket.acquire", AsyncMock()), \
-         patch("bot.main.bot_tokens.set"):
+    with (
+        patch("bot.main.adapter_client.login_adapter", AsyncMock(return_value=True)),
+        patch("bot.main.bot_bucket.acquire", AsyncMock()),
+        patch("bot.main.bot_tokens.set"),
+    ):
         asyncio.run(main.fl_login(interaction))
-    interaction.response.send_message.assert_called_once_with("Adapter login successful")
+    interaction.response.send_message.assert_called_once_with(
+        "Adapter login successful"
+    )
 
 
 def test_fl_login_failure():
     interaction = AsyncMock()
     interaction.response.send_message = AsyncMock()
-    with patch("bot.main.adapter_client.login_adapter", AsyncMock(return_value=False)), \
-         patch("bot.main.bot_bucket.acquire", AsyncMock()), \
-         patch("bot.main.bot_tokens.set"):
+    with (
+        patch("bot.main.adapter_client.login_adapter", AsyncMock(return_value=False)),
+        patch("bot.main.bot_bucket.acquire", AsyncMock()),
+        patch("bot.main.bot_tokens.set"),
+    ):
         asyncio.run(main.fl_login(interaction))
     interaction.response.send_message.assert_called_once_with("Adapter login failed")

--- a/bot/tests/test_telegram_bridge.py
+++ b/bot/tests/test_telegram_bridge.py
@@ -61,7 +61,9 @@ def test_bridge_forwards_messages():
 def test_add_remove_mapping(save_cfg):
     bot = FakeBot(2)
     tg_client = FakeTelegramClient()
-    bridge = TelegramBridge(bot, client=tg_client, config={"telegram_bridge": {"mappings": {}}})
+    bridge = TelegramBridge(
+        bot, client=tg_client, config={"telegram_bridge": {"mappings": {}}}
+    )
     asyncio.run(bridge.start())
     bridge.add_mapping(20, 2)
     event = SimpleNamespace(chat_id=20, raw_text="hi")

--- a/bot/tests/test_writings_subscription.py
+++ b/bot/tests/test_writings_subscription.py
@@ -16,12 +16,12 @@ FIXTURES = Path(__file__).parent / "fixtures"
 async def run_poll(db, sub_id: int, items: list[dict]):
     channel = AsyncMock()
     channel.send = AsyncMock()
-    with patch(
-        "bot.main.adapter_client.fetch_writings", AsyncMock(return_value=items)
-    ), patch.object(main.bot, "get_channel", return_value=channel), patch.object(
-        main.bot.scheduler, "add_job"
-    ), patch("bot.main.bot_bucket.acquire", AsyncMock()), patch(
-        "bot.main.bot_tokens.set"
+    with (
+        patch("bot.main.adapter_client.fetch_writings", AsyncMock(return_value=items)),
+        patch.object(main.bot, "get_channel", return_value=channel),
+        patch.object(main.bot.scheduler, "add_job"),
+        patch("bot.main.bot_bucket.acquire", AsyncMock()),
+        patch("bot.main.bot_tokens.set"),
     ):
         await main.poll_adapter(db, sub_id, {"interval": 60})
     return channel

--- a/bot/utils.py
+++ b/bot/utils.py
@@ -43,17 +43,14 @@ def matches_filters(item: Dict[str, Any], filters: Dict[str, Any]) -> bool:
     if city and item.get("city", "").lower() != str(city).lower():
         return False
     min_attendees = filters.get("min_attendees")
-    if (
-        isinstance(min_attendees, int)
-        and int(item.get("attendees", 0)) < min_attendees
-    ):
+    if isinstance(min_attendees, int) and int(item.get("attendees", 0)) < min_attendees:
         return False
     return True
 
 
 def format_event_embed(event: Dict[str, Any]) -> discord.Embed:
     """Return a Discord embed for *event*."""
-    title = f"\U0001F4C5 {event.get('title', '')}"
+    title = f"\U0001f4c5 {event.get('title', '')}"
     description = event.get("link", "")
     embed = discord.Embed(title=title, description=description)
     if "time" in event:

--- a/docs/decisions/2025-08-15.md
+++ b/docs/decisions/2025-08-15.md
@@ -1,0 +1,15 @@
+# 2025-08-15
+
+## Decision
+Adopt Black for Python code formatting and define flake8 settings for compatibility.
+
+## Status
+Accepted
+
+## Context
+The project previously relied on flake8 without a formatter, leading to style drift. Standardizing on Black simplifies code style and enables automated formatting.
+
+## Consequences
+- Added `make fmt` target for running Black.
+- `make check` now runs `black --check` alongside existing lint and test steps.
+- Contributors must format code with Black before committing.

--- a/plan.md
+++ b/plan.md
@@ -4,27 +4,29 @@
 - Languages: Python, PHP.
 - Build tools: setuptools via `pyproject.toml`, Composer for PHP.
 - Package managers: pip (requirements.txt), Composer.
-- Test commands: `make check` (lint, unit tests, integration tests) and `bash scripts/agents-verify.sh`.
+- Test commands: `make check` (lint, formatting, unit tests, integration tests) and `bash scripts/agents-verify.sh`.
 - Entry points: `python -m bot.main` for the bot, adapter service via PHP.
 - CI jobs: `release-hygiene.yml` (make check, version/changelog verification, agents drift check) and `release.yml` (tags and notes).
 - Release process: bump version in `pyproject.toml`, update `CHANGELOG.md`, tag `vX.Y.Z` on main.
 
 ## Goal
-Switch bot execution to module invocation and update all references from `python bot/main.py` to `python -m bot.main`.
+Add Black code formatting and flake8 configuration, provide a fmt target, and ensure check runs Black.
 
 ## Constraints
-- Update `docker-compose.yml`, `bot/Dockerfile`, `scripts/setup.sh`, and documentation.
-- Preserve commit conventions and run repository checks.
+- Configure flake8 to align with Black.
+- Add Black dependency to requirements files.
+- Update Makefile and developer docs (Agents.md).
+- Run formatters and tests via Docker.
 - Bump patch version and changelog.
 
 ## Risks
-- Missing environment variables may cause startup failure when verifying.
-- Potential overlooked references to old command.
+- Black reformatting could introduce merge conflicts or stylistic adjustments.
+- Requirements lock might drift if not regenerated.
 
 ## Test Plan
+- `docker compose build` & `make fmt`
 - `bash scripts/agents-verify.sh`
 - `make check`
-- `python -m bot.main` (expect failure without token but confirms entry point)
 
 ## Semver
-Patch: command and documentation adjustments only.
+Patch: tooling and configuration only.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fetlife-discord-bot"
-version = "0.8.1"
+version = "0.8.2"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 classifiers = [
@@ -10,3 +10,7 @@ classifiers = [
 [build-system]
 requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
+
+[tool.black]
+line-length = 88
+target-version = ["py311"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ PyYAML==6.0.2
 jsonschema==4.25.0
 
 telethon==1.36.0
+black==25.1.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203, E402, E501, W503


### PR DESCRIPTION
## Summary
- configure flake8/black settings via `setup.cfg` and `pyproject.toml`
- add `make fmt` and run black checks in `make check`
- format Python sources with Black

## Rationale
- ensure consistent formatting and linting across the project

## Testing
- `black --check bot`
- `flake8 bot`
- `pytest` *(fails: ValueError: Duplicated timeseries in CollectorRegistry)*
- `make check` *(fails: Cannot connect to the Docker daemon)*
- `bash scripts/agents-verify.sh`

## SemVer
- Patch

## Checklist
- [x] Updated version file(s)
- [x] Updated CHANGELOG.md
- [ ] Tests/CI green
- [x] AGENTS.md synced with reality

------
https://chatgpt.com/codex/tasks/task_e_689a672b2160833291fedccaec9662fc