### PR TITLE
ci(agents): verify tool presence in spec (v0.8.4)

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -387,4 +387,5 @@ Contact: Open an issue with logs (redacted), guild/channel IDs, subscription con
 
 19) CI & Release
 release-hygiene GitHub workflow runs `make check`, ensures version in `pyproject.toml` matches `CHANGELOG.md`, and executes `scripts/agents-verify.sh`.
+`scripts/agents-verify.sh` verifies that tools referenced in this spec (e.g., `docker`, `make check`, `flake8`, `phpunit`) are installed and fails if any are missing.
 Releases are tagged from `main` and publish notes from `.github/RELEASE_NOTES.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+## [0.8.4] - 2025-08-11
+### Added
+- agents-verify script validates presence of tools referenced in Agents.md (docker, make check, flake8, phpunit).
+
+
 ## [0.8.3] - 2025-08-11
 ### Added
 - MyPy static type checking and integration into `make check`.

--- a/plan.md
+++ b/plan.md
@@ -4,30 +4,27 @@
 - Languages: Python, PHP.
 - Build tools: setuptools via `pyproject.toml`, Composer for PHP.
 - Package managers: pip (requirements.txt), Composer.
-- Test commands: `make check` (lint, formatting, unit tests, integration tests) and `bash scripts/agents-verify.sh`.
+- Test commands: `make check` (uses Docker) and `bash scripts/agents-verify.sh`.
 - Entry points: `python -m bot.main` for the bot, adapter service via PHP.
-- CI jobs: `release-hygiene.yml` (make check, version/changelog verification, agents drift check) and `release.yml` (tags and notes).
+- CI jobs: `release-hygiene.yml` and `release.yml`.
 - Release process: bump version in `pyproject.toml`, update `CHANGELOG.md`, tag `vX.Y.Z` on main.
 
 ## Goal
-Add mypy static type checking for the `bot` package and integrate it into the development workflow.
+Enhance `scripts/agents-verify.sh` to ensure tools referenced in `Agents.md` exist and document these checks.
 
 ## Constraints
-- Add mypy and required type stubs to requirements files.
-- Configure mypy in `pyproject.toml` targeting `bot/`.
-- Update Makefile and developer docs (Agents.md).
-- Resolve existing type errors.
+- Verify presence of `docker`, `make check` target, `flake8`, and `phpunit` when mentioned in `Agents.md`.
+- Fail the script if any referenced command or file is missing.
+- Update `Agents.md` to describe the new verification.
 - Bump patch version and changelog.
 
 ## Risks
-- Missing type stubs for dependencies may require ignores.
-- Requirements lock might drift if not regenerated.
+- Missing system dependencies (e.g., Docker daemon) may cause checks to fail.
+- Installing required tooling can be slow in CI environments.
 
 ## Test Plan
-- `docker compose build`
 - `bash scripts/agents-verify.sh`
-- `make fmt`
-- `make check`
+- `make check` (may fail if Docker is unavailable)
 
 ## Semver
-Patch: tooling and typing only.
+Patch: CI tooling only.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fetlife-discord-bot"
-version = "0.8.3"
+version = "0.8.4"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 classifiers = [

--- a/scripts/agents-verify.sh
+++ b/scripts/agents-verify.sh
@@ -13,4 +13,39 @@ if grep -q "pnpm" Agents.md && ! grep -Rq "pnpm" .; then
   exit 1
 fi
 
+# Verify tool references
+if grep -qi "docker" Agents.md; then
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "Agents.md references docker but docker is not installed." >&2
+    exit 1
+  fi
+fi
+
+if grep -qi "make check" Agents.md; then
+  if ! command -v make >/dev/null 2>&1; then
+    echo "Agents.md references make but make is not installed." >&2
+    exit 1
+  fi
+  if ! grep -qE '^check:' Makefile; then
+    echo "Agents.md references make check but no 'check' target found in Makefile." >&2
+    exit 1
+  fi
+fi
+
+if grep -qi "flake8" Agents.md; then
+  if ! command -v flake8 >/dev/null 2>&1; then
+    echo "Agents.md references flake8 but flake8 is not installed." >&2
+    exit 1
+  fi
+fi
+
+if grep -qi "phpunit" Agents.md; then
+  if command -v phpunit >/dev/null 2>&1 || [ -f vendor/bin/phpunit ]; then
+    :
+  else
+    echo "Agents.md references phpunit but phpunit is not installed." >&2
+    exit 1
+  fi
+fi
+
 echo "Agents.md passes basic drift check."


### PR DESCRIPTION
### Summary
- ensure `scripts/agents-verify.sh` checks for tooling mentioned in `Agents.md`
- document tooling verification in `Agents.md`
- bump version to v0.8.4 and update changelog

### SemVer
- [x] patch (bugfix)
- [ ] minor (backwards-compatible feature)
- [ ] major (breaking change)
Reason: CI scripting and docs only.

### Checks
- [x] Updated version file(s)
- [x] Updated CHANGELOG.md
- [ ] Tests/CI green
- [x] AGENTS.md synced with reality


------
https://chatgpt.com/codex/tasks/task_e_689a70a7b5d48332b3704b09ce83674c