### PR TITLE
build(docker): use multi-stage Dockerfiles with pinned digests (v1.0.1)

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -389,3 +389,9 @@ Contact: Open an issue with logs (redacted), guild/channel IDs, subscription con
 release-hygiene GitHub workflow runs `make check`, ensures version in `pyproject.toml` matches `CHANGELOG.md`, and executes `scripts/agents-verify.sh`.
 `scripts/agents-verify.sh` verifies that tools referenced in this spec (e.g., `docker`, `make check`, `flake8`, `phpunit`) are installed and fails if any are missing.
 Releases are tagged from `main` and publish notes from `.github/RELEASE_NOTES.md`.
+
+20) Docker Images
+Adapter and bot Dockerfiles use multi-stage builds with base images pinned to immutable digests for reproducible builds and smaller attack surfaces:
+- `php:8.2-cli@sha256:304cfb487bbe9b2ce5a933f6e5848e0248bff1fbb0d5ee36cec845f4a34f4fb1`
+- `python:3.11-slim@sha256:0ce77749ac83174a31d5e107ce0cfa6b28a2fd6b0615e029d9d84b39c48976ee`
+Builder stages install toolchains and dependencies; runtime stages contain only application code and installed packages. Update digests alongside security releases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+## [1.0.1] - 2025-08-11
+### Changed
+- Convert adapter and bot Dockerfiles to multi-stage builds with pinned base image digests.
+
+
 ## [1.0.0] - 2025-08-11
 ### Added
 - Token-based adapter authentication via `ADAPTER_AUTH_TOKEN`.

--- a/adapter/Dockerfile
+++ b/adapter/Dockerfile
@@ -1,18 +1,21 @@
-FROM php:8.2-cli
+# syntax=docker/dockerfile:1
+FROM php:8.2-cli@sha256:304cfb487bbe9b2ce5a933f6e5848e0248bff1fbb0d5ee36cec845f4a34f4fb1 AS builder
 
 WORKDIR /app
 
-# Install composer
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git unzip \
     && rm -rf /var/lib/apt/lists/* \
     && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 
-# Install PHP dependencies
 COPY composer.json composer.lock ./
-RUN composer install --no-interaction --prefer-dist
+RUN composer install --no-interaction --prefer-dist --no-dev
 
-# Copy source and public files
+FROM php:8.2-cli@sha256:304cfb487bbe9b2ce5a933f6e5848e0248bff1fbb0d5ee36cec845f4a34f4fb1
+
+WORKDIR /app
+
+COPY --from=builder /app/vendor ./vendor
 COPY src/ src/
 COPY adapter/public/ public/
 

--- a/bot/Dockerfile
+++ b/bot/Dockerfile
@@ -1,18 +1,24 @@
-FROM node:18-bullseye
+# syntax=docker/dockerfile:1
+FROM python:3.11-slim@sha256:0ce77749ac83174a31d5e107ce0cfa6b28a2fd6b0615e029d9d84b39c48976ee AS builder
 
 WORKDIR /app
 
-# Install Python
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends python3 python3-pip \
+    && apt-get install -y --no-install-recommends build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Python dependencies
-COPY requirements.txt ./
-RUN pip3 install --no-cache-dir -r requirements.txt \
-    && pip3 install --no-cache-dir pytest flake8
+COPY requirements.txt .
+RUN python -m venv /venv \
+    && /venv/bin/pip install --no-cache-dir -r requirements.txt
 
+FROM python:3.11-slim@sha256:0ce77749ac83174a31d5e107ce0cfa6b28a2fd6b0615e029d9d84b39c48976ee
+
+WORKDIR /app
+ENV PATH="/venv/bin:$PATH"
+
+COPY --from=builder /venv /venv
 COPY bot/ bot/
+RUN rm -rf bot/tests
 
 EXPOSE 3000
-CMD ["python3", "-m", "bot.main"]
+CMD ["python", "-m", "bot.main"]

--- a/docs/decisions/2025-08-11.md
+++ b/docs/decisions/2025-08-11.md
@@ -62,3 +62,12 @@ Introduce a `group_posts` subscription type with target validation and polling t
 
 ## Consequences
 Channels can follow group posts but additional polling may increase adapter workload.
+
+## Context
+Dockerfiles produced large images and mutable builds.
+
+## Decision
+Use multi-stage builds for adapter and bot and pin base images to digests.
+
+## Consequences
+Smaller, reproducible images but digests must be updated for upstream fixes.

--- a/plan.md
+++ b/plan.md
@@ -10,23 +10,24 @@
 - Release process: bump version in `pyproject.toml`, update `CHANGELOG.md`, tag `vX.Y.Z` on main.
 
 ## Goal
-Require a shared token for adapter requests using middleware, configured via `ADAPTER_AUTH_TOKEN`, and document the setup.
+Convert Dockerfiles to multi-stage builds with pinned base image digests and document the rationale.
 
 ## Constraints
-- Middleware in `adapter/public/index.php` must enforce `Authorization: Bearer <token>` from `ADAPTER_AUTH_TOKEN`.
-- Requests with missing/invalid token return HTTP 401.
-- Update adapter client to send the token from environment variable.
-- Include token variable in Docker Compose, `.env.example`, README, and Agents spec.
+- `adapter/Dockerfile` and `bot/Dockerfile` use multi-stage builds.
+- Final stages contain only runtime dependencies and application code.
+- Pin base images: `php:8.2-cli@sha256:304cfb487bbe9b2ce5a933f6e5848e0248bff1fbb0d5ee36cec845f4a34f4fb1` and `python:3.11-slim@sha256:0ce77749ac83174a31d5e107ce0cfa6b28a2fd6b0615e029d9d84b39c48976ee`.
+- Update `Agents.md` with pinned versions and build rationale.
 - Bump version and changelog; add decision log entry.
 
 ## Risks
-- Existing deployments without token will fail to authenticate.
-- Token leakage in logs or configs could expose adapter.
+- Pinned digests require manual updates for upstream security fixes.
+- Missing runtime tools if build-stage packages are omitted.
 
 ## Test Plan
 - `bash scripts/agents-verify.sh`
+- `make fmt` (fails: docker compose plugin missing)
+- `make check` (fails: docker compose plugin missing)
 - `pytest bot/tests/test_adapter_client.py::test_auth_header`
-- `make check` (may fail if Docker is unavailable)
 
 ## Semver
-Major: adapter API now requires authentication.
+Patch: build changes only.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fetlife-discord-bot"
-version = "1.0.0"
+version = "1.0.1"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 classifiers = [


### PR DESCRIPTION
### Summary
- use multi-stage Dockerfiles for adapter and bot
- pin php:8.2-cli and python:3.11-slim base images by digest
- document pinned images and rationale in Agents spec

### SemVer
- [x] patch
- [ ] minor
- [ ] major
Reason: build system changes only.

### Checks
- [x] Updated version file(s)
- [x] Updated CHANGELOG.md
- [ ] Tests/CI green *(make fmt/check require docker compose)*
- [x] AGENTS.md synced with reality

------
https://chatgpt.com/codex/tasks/task_e_689a7a52922083329ad194e01f56db31