### PR TITLE
ci(php): add phpstan static analysis (v1.0.1)

### DIFF
--- a/.github/workflows/release-hygiene.yml
+++ b/.github/workflows/release-hygiene.yml
@@ -11,6 +11,8 @@ jobs:
           fetch-depth: 0
       - name: make check
         run: make check
+      - name: phpstan
+        run: docker compose run --rm adapter vendor/bin/phpstan analyse
       - name: Detect version and ensure CHANGELOG updated
         run: |
           set -euo pipefail

--- a/Agents.md
+++ b/Agents.md
@@ -356,7 +356,7 @@ One feature per PR; include tests and docs updates.
 
 No secrets in code or logs.
 
-Run `make fmt` for Black formatting and `make check` (formatting check, lint, type checking, tests, schema) before PR.
+Run `make fmt` for Black formatting and `make check` (formatting check, lint, type checking, static analysis, tests, schema) before PR.
 
 Follow semantic commits and Conventional Changelog.
 
@@ -386,6 +386,6 @@ Contact: Open an issue with logs (redacted), guild/channel IDs, subscription con
 
 
 19) CI & Release
-release-hygiene GitHub workflow runs `make check`, ensures version in `pyproject.toml` matches `CHANGELOG.md`, and executes `scripts/agents-verify.sh`.
-`scripts/agents-verify.sh` verifies that tools referenced in this spec (e.g., `docker`, `make check`, `flake8`, `phpunit`) are installed and fails if any are missing.
+release-hygiene GitHub workflow runs `make check`, executes `vendor/bin/phpstan analyse`, ensures version in `pyproject.toml` matches `CHANGELOG.md`, and executes `scripts/agents-verify.sh`.
+`scripts/agents-verify.sh` verifies that tools referenced in this spec (e.g., `docker`, `make check`, `flake8`, `phpunit`, `phpstan`) are installed and fails if any are missing.
 Releases are tagged from `main` and publish notes from `.github/RELEASE_NOTES.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+## [1.0.1] - 2025-08-17
+### Added
+- PHPStan static analysis with `vendor/bin/phpstan analyse`.
+
 ## [1.0.0] - 2025-08-11
 ### Added
 - Token-based adapter authentication via `ADAPTER_AUTH_TOKEN`.

--- a/Makefile
+++ b/Makefile
@@ -12,4 +12,5 @@ check:
 	docker compose -f tests/docker-compose.test.yml build
 	docker compose -f tests/docker-compose.test.yml run --rm bot-test
 	docker compose -f tests/docker-compose.test.yml down || true
+	docker compose run --rm adapter vendor/bin/phpstan analyse
 	docker compose run --rm adapter vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
         "php": "^8.2"
     },
     "require-dev": {
-        "phpunit/phpunit": "9.6.23"
+        "phpunit/phpunit": "9.6.23",
+        "phpstan/phpstan": "^1.11"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "55e07e759c81ea45e07e8ee592d86ffc",
+    "content-hash": "8c68c60048496416450d20c94d8c8876",
     "packages": [],
     "packages-dev": [
         {
@@ -312,6 +312,64 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.12.28",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "fcf8b71aeab4e1a1131d1783cef97b23a51b87a9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/fcf8b71aeab4e1a1131d1783cef97b23a51b87a9",
+                "reference": "fcf8b71aeab4e1a1131d1783cef97b23a51b87a9",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-07-17T17:15:39+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/docs/decisions/2025-08-17.md
+++ b/docs/decisions/2025-08-17.md
@@ -1,0 +1,2 @@
+# 2025-08-17
+- Added PHPStan static analysis and integrated it into `make check` and CI.

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,4 @@
+parameters:
+    level: 1
+    paths:
+        - src

--- a/plan.md
+++ b/plan.md
@@ -10,23 +10,22 @@
 - Release process: bump version in `pyproject.toml`, update `CHANGELOG.md`, tag `vX.Y.Z` on main.
 
 ## Goal
-Require a shared token for adapter requests using middleware, configured via `ADAPTER_AUTH_TOKEN`, and document the setup.
+Integrate PHPStan static analysis into the project.
 
 ## Constraints
-- Middleware in `adapter/public/index.php` must enforce `Authorization: Bearer <token>` from `ADAPTER_AUTH_TOKEN`.
-- Requests with missing/invalid token return HTTP 401.
-- Update adapter client to send the token from environment variable.
-- Include token variable in Docker Compose, `.env.example`, README, and Agents spec.
-- Bump version and changelog; add decision log entry.
+- Add `phpstan/phpstan` as a development dependency.
+- Provide `phpstan.neon.dist` with analysis level and paths.
+- Update `Makefile` and `release-hygiene.yml` to run `vendor/bin/phpstan analyse`.
+- Ensure documentation and tooling references mention PHPStan.
 
 ## Risks
-- Existing deployments without token will fail to authenticate.
-- Token leakage in logs or configs could expose adapter.
+- PHPStan may surface existing type errors.
+- Docker environments without PHPStan installed will fail `make check`.
 
 ## Test Plan
+- `vendor/bin/phpstan analyse`
 - `bash scripts/agents-verify.sh`
-- `pytest bot/tests/test_adapter_client.py::test_auth_header`
-- `make check` (may fail if Docker is unavailable)
+- `make check` (runs formatters, linters, tests, and PHPStan)
 
 ## Semver
-Major: adapter API now requires authentication.
+Patch: development tooling only.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fetlife-discord-bot"
-version = "1.0.0"
+version = "1.0.1"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 classifiers = [

--- a/scripts/agents-verify.sh
+++ b/scripts/agents-verify.sh
@@ -48,4 +48,13 @@ if grep -qi "phpunit" Agents.md; then
   fi
 fi
 
+if grep -qi "phpstan" Agents.md; then
+  if command -v phpstan >/dev/null 2>&1 || [ -f vendor/bin/phpstan ]; then
+    :
+  else
+    echo "Agents.md references phpstan but phpstan is not installed." >&2
+    exit 1
+  fi
+fi
+
 echo "Agents.md passes basic drift check."


### PR DESCRIPTION
### Summary
- require phpstan/phpstan for development
- run `vendor/bin/phpstan analyse` via Makefile and CI
- document PHPStan and update drift checks

### Rationale
Adds PHP static analysis to catch type issues earlier and enforce consistency with project tooling.

### Tests
- `bash scripts/agents-verify.sh` *(fails: Agents.md references flake8 but flake8 is not installed)*
- `pip install flake8`
- `bash scripts/agents-verify.sh`
- `vendor/bin/phpstan analyse`
- `make check` *(fails: docker: 'compose' is not a docker command)*

### SemVer
- Patch: development tooling only.

### Checklist
- [x] Updated version file(s)
- [x] Updated CHANGELOG.md
- [x] Tests/CI run
- [x] AGENTS.md synced with reality


------
https://chatgpt.com/codex/tasks/task_e_689a7b64a5bc8332ae2482630eb40f94