### PR TITLE
feat(install): add environment setup script (v1.1.0)

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -336,8 +336,7 @@ bash
 Copy
 Edit
 # 1) Launch adapter + bot (docker compose)
-cp .env.example .env && edit .env
-docker compose up -d
+bash scripts/install.sh --compose
 
 # 2) In Discord: invite the bot; run:
 # /fl login   (admin channel)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+## [1.1.0] - 2025-08-12
+### Added
+- `scripts/install.sh` to configure environment, install dependencies, run migrations, and optionally start Docker Compose.
+### Changed
+- README instructions now reference `scripts/install.sh`.
+
 ## [1.0.1] - 2025-08-11
 ### Changed
 - Convert adapter and bot Dockerfiles to multi-stage builds with pinned base image digests.

--- a/README.markdown
+++ b/README.markdown
@@ -8,10 +8,8 @@ The `bot/` directory contains a Python application using `discord.py` that relay
 
 ### Docker Compose Quick Start
 
-1. `cp .env.example .env` and edit the file with your FetLife credentials, Discord token, and database settings.
-2. `docker compose up -d` to launch the adapter, bot, and database.
-3. `docker compose run --rm bot alembic upgrade head` to apply database migrations.
-4. Generate an invite link from the [Discord Developer Portal](https://discord.com/developers/applications), invite the bot to your server, then run `/fl login` to verify adapter authentication, `/fl subscribe events location:cities/5898 min_attendees:10`, `/fl subscribe group_posts group:1`, `/fl list`, and `/fl test <id>` in Discord.
+1. `bash scripts/install.sh --compose` and supply credentials when prompted. This writes `.env`, installs dependencies, applies migrations, and launches the adapter, bot, and database.
+2. Generate an invite link from the [Discord Developer Portal](https://discord.com/developers/applications), invite the bot to your server, then run `/fl login` to verify adapter authentication, `/fl subscribe events location:cities/5898 min_attendees:10`, `/fl subscribe group_posts group:1`, `/fl list`, and `/fl test <id>` in Discord.
 
 ### Environment Variables
 
@@ -47,14 +45,7 @@ docker compose run --rm bot alembic upgrade head
 
 ### Manual Setup
 
-1. Copy `.env.example` to `.env` and fill in your FetLife credentials, Discord token, database details, and any proxy settings:
-
-   ```bash
-   cp .env.example .env
-   ```
-
-   The `.env` file contains secrets and **must not** be committed to version control.
-
+1. `bash scripts/install.sh` and provide credentials when prompted. This writes `.env`, installs dependencies, and applies migrations. The `.env` file contains secrets and **must not** be committed to version control.
 2. Customize `config.yaml` for per-guild or per-channel defaults. A minimal example:
 
    ```yaml

--- a/docs/decisions/2025-08-12.md
+++ b/docs/decisions/2025-08-12.md
@@ -3,3 +3,4 @@
 ## Added
 - Introduced a Telegram bridge using Telethon to relay chat messages into Discord.
 - Mappings stored in `config.yaml` and managed at runtime with `/fl telegram` commands.
+- Added `scripts/install.sh` for credential prompting, dependency installation, migrations, and optional Docker Compose startup.

--- a/plan.md
+++ b/plan.md
@@ -4,30 +4,31 @@
 - Languages: Python, PHP.
 - Build tools: setuptools via `pyproject.toml`, Composer for PHP.
 - Package managers: pip (requirements.txt), Composer.
-- Test commands: `make check` (uses Docker) and `bash scripts/agents-verify.sh`.
+- Test commands: `make check` and `bash scripts/agents-verify.sh`.
 - Entry points: `python -m bot.main` for the bot, adapter service via PHP.
 - CI jobs: `release-hygiene.yml` and `release.yml`.
 - Release process: bump version in `pyproject.toml`, update `CHANGELOG.md`, tag `vX.Y.Z` on main.
 
 ## Goal
-Convert Dockerfiles to multi-stage builds with pinned base image digests and document the rationale.
+Create `scripts/install.sh` that collects credentials, writes `.env`, installs dependencies, runs `alembic upgrade head`, and optionally launches Docker Compose. Update documentation to reference the new script.
 
 ## Constraints
-- `adapter/Dockerfile` and `bot/Dockerfile` use multi-stage builds.
-- Final stages contain only runtime dependencies and application code.
-- Pin base images: `php:8.2-cli@sha256:304cfb487bbe9b2ce5a933f6e5848e0248bff1fbb0d5ee36cec845f4a34f4fb1` and `python:3.11-slim@sha256:0ce77749ac83174a31d5e107ce0cfa6b28a2fd6b0615e029d9d84b39c48976ee`.
-- Update `Agents.md` with pinned versions and build rationale.
-- Bump version and changelog; add decision log entry.
+- Script accepts flags or interactive prompts for required credentials.
+- Writes `.env` without overwriting existing keys.
+- Installs Python (`pip install -r requirements.txt`) and PHP (`composer install`) dependencies.
+- Runs database migrations via `alembic upgrade head`.
+- Optional `docker compose up -d` invocation.
+- Update `README.markdown` and `Agents.md` to reference the script.
+- Bump minor version and changelog entry.
 
 ## Risks
-- Pinned digests require manual updates for upstream security fixes.
-- Missing runtime tools if build-stage packages are omitted.
+- Dependency installation or migrations may fail if tools are missing.
+- Docker Compose may not be installed; script must handle absence gracefully.
 
 ## Test Plan
 - `bash scripts/agents-verify.sh`
-- `make fmt` (fails: docker compose plugin missing)
-- `make check` (fails: docker compose plugin missing)
-- `pytest bot/tests/test_adapter_client.py::test_auth_header`
+- `make fmt` (may fail: docker compose plugin missing)
+- `make check` (may fail: docker compose plugin missing)
 
 ## Semver
-Patch: build changes only.
+Minor: adds backwards-compatible installation helper.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fetlife-discord-bot"
-version = "1.0.1"
+version = "1.1.0"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 classifiers = [

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'USAGE'
+Usage: $0 [-u username] [-p password] [-t token] [--compose]
+Prompts for any missing values and writes .env, installs dependencies,
+runs alembic upgrade head, and optionally launches docker compose.
+USAGE
+}
+
+ENV_FILE=".env"
+COMPOSE=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -u|--username)
+      FETLIFE_USERNAME="$2"
+      shift 2
+      ;;
+    -p|--password)
+      FETLIFE_PASSWORD="$2"
+      shift 2
+      ;;
+    -t|--token)
+      DISCORD_TOKEN="$2"
+      shift 2
+      ;;
+    --compose)
+      COMPOSE=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+prompt() {
+  local name="$1" default="${2-}"
+  local val
+  read -r -p "$name${default:+ [$default]}: " val
+  if [[ -z "$val" ]]; then
+    val="$default"
+  fi
+  printf '%s' "$val"
+}
+
+write_env() {
+  local key="$1" value="$2"
+  if [[ -f "$ENV_FILE" ]] && grep -q "^${key}=" "$ENV_FILE"; then
+    echo "$key already set in $ENV_FILE; skipping."
+  else
+    echo "$key=$value" >> "$ENV_FILE"
+  fi
+}
+
+if [[ ! -f "$ENV_FILE" ]]; then
+  touch "$ENV_FILE"
+  echo "Created $ENV_FILE"
+fi
+
+: "${FETLIFE_USERNAME:=$(prompt FETLIFE_USERNAME)}"
+: "${FETLIFE_PASSWORD:=$(prompt FETLIFE_PASSWORD)}"
+: "${DISCORD_TOKEN:=$(prompt DISCORD_TOKEN)}"
+
+DB_HOST=$(prompt DB_HOST "localhost")
+DB_PORT=$(prompt DB_PORT "5432")
+DB_NAME=$(prompt DB_NAME "bot")
+DB_USER=$(prompt DB_USER "bot")
+DB_PASSWORD=$(prompt DB_PASSWORD)
+
+write_env FETLIFE_USERNAME "$FETLIFE_USERNAME"
+write_env FETLIFE_PASSWORD "$FETLIFE_PASSWORD"
+write_env DISCORD_TOKEN "$DISCORD_TOKEN"
+write_env DB_HOST "$DB_HOST"
+write_env DB_PORT "$DB_PORT"
+write_env DB_NAME "$DB_NAME"
+write_env DB_USER "$DB_USER"
+write_env DB_PASSWORD "$DB_PASSWORD"
+
+echo "Installing Python dependencies..."
+pip install -r requirements.txt
+
+if command -v composer >/dev/null 2>&1; then
+  echo "Installing PHP dependencies..."
+  composer install --no-interaction
+else
+  echo "composer not found; skipping PHP dependencies."
+fi
+
+echo "Applying database migrations..."
+alembic upgrade head
+
+if [[ $COMPOSE -eq 1 ]]; then
+  if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+    echo "Starting services via docker compose..."
+    docker compose up -d
+  else
+    echo "Docker Compose not available; skipping."
+  fi
+else
+  read -r -p "Launch docker compose now? (y/N): " launch
+  if [[ "$launch" =~ ^[Yy]$ ]]; then
+    if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+      docker compose up -d
+    else
+      echo "Docker Compose not available; skipping."
+    fi
+  fi
+fi
+
+cat <<'EON'
+Next steps:
+1. Invite the bot via the Discord Developer Portal.
+2. Run /fl login in your Discord server to verify connectivity.
+3. Add subscriptions with /fl subscribe.
+EON


### PR DESCRIPTION
### Summary
- add `scripts/install.sh` to prompt for credentials, install dependencies, run migrations, and optionally start Docker Compose
- reference install script in README and Agents quick start
- bump version to v1.1.0

### SemVer
- [ ] patch (bugfix)
- [x] minor (backwards-compatible feature)
- [ ] major (breaking change)
Reason: adds a new installation helper without affecting existing interfaces.

### Checks
- [x] Updated version file(s)
- [x] Updated CHANGELOG.md
- [ ] Tests/CI green
- [x] AGENTS.md synced with reality


------
https://chatgpt.com/codex/tasks/task_e_689a8a0b1e148332a56c2b00f15834cd