### PR TITLE
feat(install): add interactive virtualenv menu (v1.1.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bot/__pycache__/
 bot/tests/__pycache__/
 vendor/
 tests/.phpunit.result.cache
+.venv/

--- a/Agents.md
+++ b/Agents.md
@@ -335,8 +335,9 @@ Multi-account adapter support, per-subscription credentials.
 bash
 Copy
 Edit
-# 1) Launch adapter + bot (docker compose)
-bash scripts/install.sh --compose
+# 1) Run the installer and choose 'Install'
+bash scripts/install.sh
+docker compose up -d
 
 # 2) In Discord: invite the bot; run:
 # /fl login   (admin channel)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+## [1.1.2] - 2025-08-12
+### Added
+- Interactive `scripts/install.sh` menu for managing the Python virtual environment.
+### Changed
+- Documentation updated to reference the new installation workflow.
+
 ## [1.1.1] - 2025-08-12
 ### Changed
 - Restrict admin-level commands to administrators with error handling.

--- a/README.markdown
+++ b/README.markdown
@@ -8,8 +8,9 @@ The `bot/` directory contains a Python application using `discord.py` that relay
 
 ### Docker Compose Quick Start
 
-1. `bash scripts/install.sh --compose` and supply credentials when prompted. This writes `.env`, installs dependencies, applies migrations, and launches the adapter, bot, and database.
-2. Generate an invite link from the [Discord Developer Portal](https://discord.com/developers/applications), invite the bot to your server, then run `/fl login` to verify adapter authentication, `/fl subscribe events location:cities/5898 min_attendees:10`, `/fl subscribe group_posts group:1`, `/fl list`, and `/fl test <id>` in Discord.
+1. `bash scripts/install.sh` and select **Install**. This creates `.venv` and installs dependencies.
+2. `docker compose up -d` to launch the adapter, bot, and database.
+3. Generate an invite link from the [Discord Developer Portal](https://discord.com/developers/applications), invite the bot to your server, then run `/fl login` to verify adapter authentication, `/fl subscribe events location:cities/5898 min_attendees:10`, `/fl subscribe group_posts group:1`, `/fl list`, and `/fl test <id>` in Discord.
 
 ### Environment Variables
 
@@ -45,7 +46,7 @@ docker compose run --rm bot alembic upgrade head
 
 ### Manual Setup
 
-1. `bash scripts/install.sh` and provide credentials when prompted. This writes `.env`, installs dependencies, and applies migrations. The `.env` file contains secrets and **must not** be committed to version control.
+1. `bash scripts/install.sh` and select **Install** to create `.venv` and install dependencies. The `.env` file contains secrets and **must not** be committed to version control.
 2. Customize `config.yaml` for per-guild or per-channel defaults. A minimal example:
 
    ```yaml

--- a/docs/decisions/2025-08-12.md
+++ b/docs/decisions/2025-08-12.md
@@ -3,5 +3,5 @@
 ## Added
 - Introduced a Telegram bridge using Telethon to relay chat messages into Discord.
 - Mappings stored in `config.yaml` and managed at runtime with `/fl telegram` commands.
-- Added `scripts/install.sh` for credential prompting, dependency installation, migrations, and optional Docker Compose startup.
+- Added `scripts/install.sh` with an interactive menu for virtual environment management and dependency installation.
 - Enforced administrator permissions on sensitive commands and added error handling with ephemeral responses.

--- a/plan.md
+++ b/plan.md
@@ -8,18 +8,17 @@
 - Release process: bump version in `pyproject.toml`, update `CHANGELOG.md`, tag `vX.Y.Z`
 
 ## Goal
-Restrict admin-level commands to administrators, add error handling, and test unauthorized access.
+Add interactive installer menu for managing the Python virtual environment.
 
 ## Constraints
-- Apply `@app_commands.default_permissions(administrator=True)` to admin commands
-- Wrap command bodies with try/except and respond `ephemeral=True` on errors
-- Add unit tests for unauthorized access attempts
-- Update version metadata and changelog
-- Follow Conventional Commits
+- Provide Install, Reinstall, Uninstall, and Exit options
+- Warn before deleting an existing `.venv`
+- Ensure `.venv/` is ignored by git
+- Update documentation, version metadata, and changelog
 
 ## Risks
-- Permission checks may bypass tests
-- Error handling might hide underlying issues
+- Accidental removal of a developer's environment
+- Documentation drift if references are missed
 
 ## Test Plan
 - `bash scripts/agents-verify.sh`
@@ -27,4 +26,7 @@ Restrict admin-level commands to administrators, add error handling, and test un
 - `make check`
 
 ## Semver
-Patch: backward-compatible permission enforcement and tests
+Patch: tooling enhancement without API changes
+
+## Rollback
+Revert the commit and restore previous `scripts/install.sh`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fetlife-discord-bot"
-version = "1.1.1"
+version = "1.1.2"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 classifiers = [


### PR DESCRIPTION
## Summary
- add interactive menu to `scripts/install.sh` for managing the Python virtual environment
- ignore `.venv/` and update docs for new installation workflow

## Rationale
Provides explicit install, reinstall, and uninstall flows for developers.

## Semver
Patch release v1.1.2 – tooling change with no API impact.

## Testing
- `bash scripts/agents-verify.sh` (fails: docker is not installed)
- `make fmt` (fails: docker is not installed)
- `make check` (fails: docker is not installed)

## Risk
Low – affects only developer tooling. If issues arise, revert commit `b14bc3f`.

## Rollback
Revert the commit to restore the previous installer.

## Packages
- fetlife-discord-bot

## Checklist
- [x] Intake done
- [x] Plan attached
- [x] Version bumped
- [x] CHANGELOG updated
- [ ] CI green
- [x] AGENTS/ADRs synced
- [x] Tag plan ready


------
https://chatgpt.com/codex/tasks/task_e_689a8ebf433083328a156fb5c7fd0d83