### PR TITLE
chore(repo): ignore .venv virtualenv directory (v1.1.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bot/__pycache__/
 bot/tests/__pycache__/
 vendor/
 tests/.phpunit.result.cache
+.venv/

--- a/Agents.md
+++ b/Agents.md
@@ -355,6 +355,8 @@ One feature per PR; include tests and docs updates.
 
 No secrets in code or logs.
 
+Use `.venv/` for the Python virtual environment; it is the standard path and is ignored by Git.
+
 Run `make fmt` for Black formatting and `make check` (formatting check, lint, type checking, tests, schema) before PR.
 
 Follow semantic commits and Conventional Changelog.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+## [1.1.2] - 2025-08-12
+### Added
+- Document `.venv/` as the standard Python virtual environment path.
+### Changed
+- Add `.venv/` to `.gitignore`.
+
 ## [1.1.1] - 2025-08-12
 ### Changed
 - Restrict admin-level commands to administrators with error handling.

--- a/README.markdown
+++ b/README.markdown
@@ -45,6 +45,13 @@ docker compose run --rm bot alembic upgrade head
 
 ### Manual Setup
 
+Create a Python virtual environment in `.venv/` and activate it:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+```
+
 1. `bash scripts/install.sh` and provide credentials when prompted. This writes `.env`, installs dependencies, and applies migrations. The `.env` file contains secrets and **must not** be committed to version control.
 2. Customize `config.yaml` for per-guild or per-channel defaults. A minimal example:
 

--- a/plan.md
+++ b/plan.md
@@ -3,23 +3,21 @@
 - Build tools: setuptools via `pyproject.toml`, Composer for PHP
 - Package managers: pip (requirements.txt), Composer
 - Test commands: `make fmt`, `make check`, `bash scripts/agents-verify.sh`
-- Entry points: `python -m bot.main` for the bot, adapter service via PHP
+- Entry points: `python -m bot.main`, adapter service via PHP
 - CI jobs: `release-hygiene.yml`, `release.yml`
 - Release process: bump version in `pyproject.toml`, update `CHANGELOG.md`, tag `vX.Y.Z`
 
 ## Goal
-Restrict admin-level commands to administrators, add error handling, and test unauthorized access.
+Ignore local virtual environment and document its location.
 
 ## Constraints
-- Apply `@app_commands.default_permissions(administrator=True)` to admin commands
-- Wrap command bodies with try/except and respond `ephemeral=True` on errors
-- Add unit tests for unauthorized access attempts
-- Update version metadata and changelog
-- Follow Conventional Commits
+- Append `.venv/` to `.gitignore`
+- Document `.venv/` as standard virtual environment path in `Agents.md` and `README.markdown`
+- Bump version metadata and changelog
+- Follow semantic commits
 
 ## Risks
-- Permission checks may bypass tests
-- Error handling might hide underlying issues
+- Developers using different virtual environment paths may create inconsistencies
 
 ## Test Plan
 - `bash scripts/agents-verify.sh`
@@ -27,4 +25,10 @@ Restrict admin-level commands to administrators, add error handling, and test un
 - `make check`
 
 ## Semver
-Patch: backward-compatible permission enforcement and tests
+Patch: documentation and gitignore update
+
+## Affected Packages
+- root package
+
+## Rollback
+- Revert commit and restore previous version and changelog entry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fetlife-discord-bot"
-version = "1.1.1"
+version = "1.1.2"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 classifiers = [


### PR DESCRIPTION
## Summary
- ignore `.venv/` virtualenv directory
- document `.venv/` as the standard virtualenv path
- bump version to 1.1.2

## Rationale
Keeps transient Python environments out of version control and clarifies standard development setup.

## Semver
Patch: documentation and ignore updates only.

## Testing
- `python -m pip_audit -r requirements.txt` *(passed: no known vulnerabilities)*
- `composer audit` *(passed: no packages - skipping audit)*
- `bash scripts/agents-verify.sh` *(passed: Agents.md passes basic drift check)*
- `make fmt` *(failed: Error while fetching server API version - Docker daemon not available)*
- `make check` *(failed: Error while fetching server API version - Docker daemon not available)*

## Risks
Low. If issues arise, revert commit `1b76271`.

## Rollback
Revert the commit and restore previous version/changelog entries.

## Checklist
- [x] Intake done
- [x] Plan attached
- [x] Version bumped
- [x] CHANGELOG updated
- [ ] CI green *(Docker daemon unavailable in environment)*
- [x] AGENTS/ADRs synced
- [x] Tag plan ready

------
https://chatgpt.com/codex/tasks/task_e_689a8f3fba1083328f02425338e89aac