### PR TITLE
fix(db): add accounts table migration (v1.3.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+## [1.3.1] - 2025-08-12
+### Added
+- Alembic migration adding `accounts` table and `account_id` foreign key to `subscriptions`.
+
 ## [1.3.0] - 2025-08-12
 ### Added
 - `/messages` adapter endpoint and `messages` subscription forwarding DMs to Discord and Telegram.

--- a/alembic/versions/0002_add_accounts.py
+++ b/alembic/versions/0002_add_accounts.py
@@ -1,0 +1,41 @@
+"""Add accounts table and link subscriptions."""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0002_add_accounts"
+down_revision = "0001_initial"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "accounts",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("username", sa.String(), nullable=False),
+        sa.Column("credential_hash", sa.String(), nullable=False, unique=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    with op.batch_alter_table("subscriptions") as batch_op:
+        batch_op.add_column(sa.Column("account_id", sa.Integer(), nullable=True))
+        batch_op.create_foreign_key(
+            "fk_subscriptions_account_id_accounts",
+            "accounts",
+            ["account_id"],
+            ["id"],
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("subscriptions") as batch_op:
+        batch_op.drop_constraint(
+            "fk_subscriptions_account_id_accounts", type_="foreignkey"
+        )
+        batch_op.drop_column("account_id")
+    op.drop_table("accounts")

--- a/plan.md
+++ b/plan.md
@@ -8,25 +8,23 @@
 - Release process: bump version in `pyproject.toml`, update `CHANGELOG.md`, tag `vX.Y.Z`
 
 ## Goal
-Add `messages` subscription relaying direct messages to Discord and Telegram via a new adapter `/messages` endpoint.
+Add Alembic migration `0002_add_accounts` creating the `accounts` table and linking it to `subscriptions` via `account_id`.
 
 ## Constraints
-- Adapter must reuse existing authenticated session.
-- Store cursors per subscription to avoid duplicate DMs.
-- Forward DMs to mapped Telegram chats when configured.
-- Update docs, schemas, and configuration to reflect new subscription type.
+- Preserve existing subscription data; new `account_id` column must be nullable.
 
 ## Risks
-- Parsing FetLife messages may break if page layout changes.
-- Telegram send failures could drop DMs silently.
+- Migration may fail if schemas drift from models.
+- Inconsistent foreign key constraints could break subscription queries.
 
 ## Test Plan
 - `bash scripts/agents-verify.sh`
 - `make fmt`
 - `make check`
+- `alembic upgrade head`
 
 ## Semver
-Minor: new functionality without breaking existing API (bump to 1.3.0).
+Patch: adds missing database structures without altering external APIs (bump to 1.3.1).
 
 ## Rollback
-Revert the commit and remove `messages` subscription and adapter endpoint.
+Revert the commit and downgrade the database via Alembic to drop the new table and column.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fetlife-discord-bot"
-version = "1.3.0"
+version = "1.3.1"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 classifiers = [


### PR DESCRIPTION
## Summary
- add Alembic migration creating `accounts` table and optional `account_id` link on `subscriptions`
- bump project version to 1.3.1 and document schema change

## Rationale
Aligns database schema with existing SQLAlchemy models enabling per-subscription account selection.

## Semver
Patch release: backward compatible schema addition.

## Test Evidence
- `bash scripts/agents-verify.sh` *(passes)*
- `black alembic/versions/0002_add_accounts.py` *(passes)*
- `flake8 alembic/versions/0002_add_accounts.py` *(passes)*
- `mypy alembic/versions/0002_add_accounts.py` *(passes)*
- `pytest` *(fails: ValueError: invalid literal for int() with base 10: '')*
- `make fmt` *(fails: cannot connect to Docker daemon)*
- `make check` *(fails: cannot connect to Docker daemon)*
- `PYTHONPATH=. alembic -c alembic_local.ini upgrade head` *(passes)*

## Risks
Running the migration on existing deployments; ensure backups before applying.

## Rollback
Revert commit and run `alembic downgrade 0001_initial` to drop the new table and column.

## Affected Packages
- root project

## Checklist
- [x] Intake done
- [x] Plan attached
- [x] Version bumped
- [x] CHANGELOG updated
- [ ] CI green
- [x] AGENTS/ADRs synced
- [ ] Tag plan ready


------
https://chatgpt.com/codex/tasks/task_e_689b115530b48332aae9b01934dbb7fc