### PR TITLE
docs(release): backfill notes for v0.9.0-v1.3.0

### DIFF
--- a/.github/RELEASE_NOTES.md
+++ b/.github/RELEASE_NOTES.md
@@ -1,8 +1,25 @@
 <!-- Release notes will be compiled here for each tagged version. -->
 
+## v1.3.0
+- `/messages` adapter endpoint with DM forwarding to Discord and Telegram.
+- Schema, tests, and docs for message relays.
+
+## v1.2.0
+- Automatic reconnection, attachment forwarding, and `/fl telegram list` for the Telegram bridge.
+- Docs updated for enhanced relay behavior.
+
+## v1.1.0
+- `scripts/install.sh` for environment setup, dependency installation, migrations, and optional Docker Compose start.
+- README now references `scripts/install.sh`.
+
+## v1.0.0
+- Token-based adapter authentication via `ADAPTER_AUTH_TOKEN`.
+
+## v0.9.0
+- Development tooling: 24/7 run instructions, Black formatting + `make fmt`, MyPy checks, and `agents-verify` script.
+
 ## v0.8.0
 - Add interactive setup script for environment configuration and migrations.
-
 
 ## v0.6.0
 - Add group post subscriptions with target validation and relay.

--- a/plan.md
+++ b/plan.md
@@ -3,31 +3,26 @@
 - Build tools: setuptools (pyproject), Composer
 - Package managers: pip, Composer
 - Tests: `bash scripts/agents-verify.sh`, `make fmt`, `make check`
-- Entrypoints: `python -m bot.main`, adapter via PHP
 - CI jobs: `release-hygiene.yml`, `release.yml`
 - Release process: bump version in `pyproject.toml`, update `CHANGELOG.md`, tag `vX.Y.Z`
 
 ## Goal
-Expose the bot's HTTP server on port 8000 in the Docker image.
+Append release notes for v0.9.0–v1.3.0 and confirm release workflow references them.
 
 ## Constraints
-- Do not alter runtime behavior beyond the Dockerfile port.
-- Preserve existing build and release tooling.
+- Follow existing release note style.
+- No version bump or changelog updates.
 
 ## Risks
-- Missing version bump or changelog entry could lead to release drift.
+- Misaligned release summaries.
 
 ## Test Plan
 - `bash scripts/agents-verify.sh`
 - `make fmt`
 - `make check`
-- `docker build -t bot-test -f bot/Dockerfile .`
-- `docker run --rm -d -p 8000:8000 -e DISCORD_TOKEN=dummy --name bot-test bot-test`
-- `curl -f http://localhost:8000/metrics`
-- `curl -f http://localhost:8000/ready || true` (expected 503 without Discord connectivity)
 
 ## Semver
-Patch bump to 1.3.3.
+No version change (documentation only).
 
 ## Rollback
-Revert the commit and rebuild the previous Docker image.
+Revert this commit.


### PR DESCRIPTION
## Summary
- summarize releases from v0.9.0 through v1.3.0 in `.github/RELEASE_NOTES.md`
- confirm release workflow pulls notes from the same path

## Rationale
- keep published release notes aligned with `CHANGELOG.md`

## Testing
- `bash scripts/agents-verify.sh` *(passes)*
- `make fmt` *(fails: docker compose not available)*
- `make check` *(fails: docker compose not available)*

## Risk
- Low: docs-only change

## Rollback
- Revert this PR

------
https://chatgpt.com/codex/tasks/task_e_689b18944f20833293e039b336dec289