### PR TITLE
chore(release): sync PHP version and release docs (v1.3.3)

### DIFF
--- a/Agents.md
+++ b/Agents.md
@@ -388,7 +388,7 @@ Contact: Open an issue with logs (redacted), guild/channel IDs, subscription con
 19) CI & Release
 release-hygiene GitHub workflow runs `make check`, ensures version in `pyproject.toml` matches `CHANGELOG.md`, and executes `scripts/agents-verify.sh`.
 `scripts/agents-verify.sh` verifies that tools referenced in this spec (e.g., `docker`, `make check`, `flake8`, `phpunit`) are installed and fails if any are missing.
-Releases are tagged from `main` and publish notes from `.github/RELEASE_NOTES.md`.
+Releases are tagged from `main` and publish notes from `.github/RELEASE_NOTES.md`. Bump Python `pyproject.toml` and PHP `composer.json` versions together.
 
 20) Docker Images
 Adapter and bot Dockerfiles use multi-stage builds with base images pinned to immutable digests for reproducible builds and smaller attack surfaces:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+### Added
+- Declare PHP package version in `composer.json` and document bumping Python and PHP versions together during releases.
+
 ## [1.3.3] - 2025-08-12
 ### Fixed
 - Expose correct bot HTTP port 8000 in Dockerfile.

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "FetLife adapter library",
     "type": "library",
     "license": "AGPL-3.0-or-later",
+    "version": "1.3.3",
     "require": {
         "php": "^8.2"
     },

--- a/plan.md
+++ b/plan.md
@@ -4,17 +4,18 @@
 - Package managers: pip, Composer
 - Tests: `bash scripts/agents-verify.sh`, `make fmt`, `make check`
 - CI jobs: `release-hygiene.yml`, `release.yml`
-- Release process: bump version in `pyproject.toml`, update `CHANGELOG.md`, tag `vX.Y.Z`
+- Release process: bump versions in `pyproject.toml` and `composer.json`, update `CHANGELOG.md`, tag `vX.Y.Z`, publish notes from `.github/RELEASE_NOTES.md`
 
 ## Goal
-Append release notes for v0.9.0–v1.3.0 and confirm release workflow references them.
+Expose PHP package version and document bumping Python and PHP versions together.
 
 ## Constraints
-- Follow existing release note style.
-- No version bump or changelog updates.
+- Keep release docs consistent with CI release checks.
+- No project version change.
 
 ## Risks
-- Misaligned release summaries.
+- Version drift between Python and PHP packages.
+- Incomplete release documentation.
 
 ## Test Plan
 - `bash scripts/agents-verify.sh`
@@ -22,7 +23,7 @@ Append release notes for v0.9.0–v1.3.0 and confirm release workflow references
 - `make check`
 
 ## Semver
-No version change (documentation only).
+No version change (documentation/metadata only) – patch.
 
 ## Rollback
 Revert this commit.


### PR DESCRIPTION
## Summary
- define PHP package version to match Python 1.3.3
- document bumping Python and PHP versions together when releasing
- record release alignment plan

## Testing
- `bash scripts/agents-verify.sh`
- `make fmt` *(fails: unknown flag: --rm)*
- `make check` *(fails: docker: 'compose' is not a docker command)*


------
https://chatgpt.com/codex/tasks/task_e_689b1a45f2848332a69eccada5b8314f