### PR TITLE
build(deps): split dev requirements (v1.3.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+## [1.3.7] - 2025-08-14
+### Changed
+- Split development dependencies into `requirements-dev.txt` and update Dockerfile, Makefile, and docs.
 ## [1.3.6] - 2025-08-12
 ### Fixed
 - Ensure adapter service restarts automatically in Docker Compose.

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,11 @@
 .PHONY: check fmt
 
 fmt:
-	docker compose run --rm bot black bot
+	docker compose run --rm bot sh -c "pip install -r requirements-dev.txt && black bot"
 
 check:
 	docker compose build
-	docker compose run --rm bot black --check bot
-	docker compose run --rm bot flake8 bot
-	docker compose run --rm bot mypy bot
-	docker compose run --rm bot pytest
+	docker compose run --rm bot sh -c "pip install -r requirements-dev.txt && black --check bot && flake8 bot && mypy bot && pytest"
 	docker compose -f tests/docker-compose.test.yml build
 	docker compose -f tests/docker-compose.test.yml run --rm bot-test
 	docker compose -f tests/docker-compose.test.yml down || true

--- a/README.markdown
+++ b/README.markdown
@@ -8,7 +8,7 @@ The `bot/` directory contains a Python application using `discord.py` that relay
 
 ### Docker Compose Quick Start
 
-1. `bash scripts/install.sh` and select **Install**. This creates `.venv` and installs dependencies.
+1. `bash scripts/install.sh` and select **Install**. This creates `.venv` and installs runtime and development dependencies.
 2. `docker compose up -d` to launch the adapter, bot, and database.
 3. Generate an invite link from the [Discord Developer Portal](https://discord.com/developers/applications), invite the bot to your server, then run `/fl login` to verify adapter authentication, `/fl subscribe events location:cities/5898 min_attendees:10`, `/fl subscribe group_posts group:1`, `/fl subscribe messages inbox`, `/fl list`, and `/fl test <id>` in Discord.
 
@@ -48,7 +48,7 @@ docker compose run --rm bot alembic upgrade head
 
 ### Manual Setup
 
-1. `bash scripts/install.sh` and select **Install** to create `.venv` and install dependencies. The `.env` file contains secrets and **must not** be committed to version control.
+1. `bash scripts/install.sh` and select **Install** to create `.venv` and install dependencies from `requirements.txt` and `requirements-dev.txt`. The `.env` file contains secrets and **must not** be committed to version control.
 2. Customize `config.yaml` for per-guild or per-channel defaults. A minimal example:
 
    ```yaml

--- a/bot/Dockerfile
+++ b/bot/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends build-essential \
     && rm -rf /var/lib/apt/lists/*
 
+# Install runtime requirements only
 COPY requirements.txt .
 RUN python -m venv /venv \
     && /venv/bin/pip install --no-cache-dir -r requirements.txt

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "FetLife adapter library",
     "type": "library",
     "license": "AGPL-3.0-or-later",
-    "version": "1.3.6",
+    "version": "1.3.7",
     "require": {
         "php": "^8.2"
     },

--- a/plan.md
+++ b/plan.md
@@ -8,26 +8,25 @@
 - Release process: bump versions in `pyproject.toml` and `composer.json`, update `CHANGELOG.md`, tag `vX.Y.Z`, publish notes from `.github/RELEASE_NOTES.md`
 
 ## Goal
-Ensure adapter service restarts automatically in Docker Compose.
+Split development dependencies from runtime and ensure tooling installs dev extras only when needed.
 
 ## Constraints
-- Follow existing YAML style.
+- Follow existing file styles.
 - Bump Python and PHP package versions together.
 
 ## Risks
-- Docker builds may fail.
-- Version bump might drift from other release artifacts.
+- Missing dev dependencies could break formatting or tests.
+- Documentation may drift from new dependency layout.
 
 ## Test Plan
 - `bash scripts/agents-verify.sh`
 - `make fmt`
-- `docker compose build`
-- `pip-audit`
+- `pip-audit -r requirements.txt -r requirements-dev.txt`
 - `composer audit`
 - `make check`
 
 ## Semver
-Patch release (deployment fix).
+Patch release (build workflow change).
 
 ## Rollback
 Revert this commit.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fetlife-discord-bot"
-version = "1.3.6"
+version = "1.3.7"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 classifiers = [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+black==25.1.0
+flake8==7.3.0
+mypy==1.17.1
+pytest==8.4.1
+types-PyYAML==6.0.12.20250809
+types-jsonschema==4.25.0.20250809

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,9 +9,3 @@ PyYAML==6.0.2
 jsonschema==4.25.0
 
 telethon==1.36.0
-black==25.1.0
-flake8==7.3.0
-
-mypy==1.17.1
-types-PyYAML==6.0.12.20250809
-types-jsonschema==4.25.0.20250809

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -15,7 +15,7 @@ install() {
   fi
   # shellcheck source=/dev/null
   source .venv/bin/activate
-  pip install -r requirements.txt
+  pip install -r requirements.txt -r requirements-dev.txt
 }
 
 reinstall() {


### PR DESCRIPTION
## Summary
- separate development dependencies into `requirements-dev.txt`
- install only runtime requirements in bot Docker image
- document dev install and wire Makefile to add dev extras
- bump version to v1.3.7

## Rationale
Lean runtime image and clearer dev tooling separation.

## Testing
- `scripts/agents-verify.sh`
- `pip-audit -r requirements.txt -r requirements-dev.txt`
- `composer audit`
- `make fmt` *(fails: unknown flag: --rm)*
- `make check` *(fails: docker: 'compose' is not a docker command)*

## Risk
Low. Revert commit to rollback.

## Rollback
Revert this commit.

## Packages Touched
- fetlife-discord-bot (Python)
- project/fetlife-discord-bot (PHP)


------
https://chatgpt.com/codex/tasks/task_e_689db072ce3883328af1700d034801ab