### PR TITLE
fix(telegram): handle missing credentials gracefully (v1.3.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+## [1.3.8] - 2025-08-14
+### Fixed
+- Allow bot to run without Telegram credentials.
+
 ## [1.3.7] - 2025-08-14
 ### Changed
 - Split development dependencies into `requirements-dev.txt` and update Dockerfile, Makefile, and docs.

--- a/README.markdown
+++ b/README.markdown
@@ -20,7 +20,7 @@ The `.env` file supports these keys:
 - `FETLIFE_PASSWORD` – FetLife account password.
 - `CREDENTIAL_SALT` – optional string combined with credentials before hashing.
 - `DISCORD_TOKEN` – Discord bot token.
-- `TELEGRAM_API_ID`, `TELEGRAM_API_HASH` – Telegram API credentials for the bridge.
+- `TELEGRAM_API_ID`, `TELEGRAM_API_HASH` – optional Telegram API credentials for the bridge.
 - `ADAPTER_AUTH_TOKEN` – shared token clients must send via `Authorization: Bearer` to the adapter.
 - `ADAPTER_BASE_URL` – base URL for the adapter service (default `http://adapter:8000`).
 - `DB_HOST`, `DB_PORT`, `DB_NAME`, `DB_USER`, `DB_PASSWORD` – database connection settings.

--- a/bot/tests/test_main.py
+++ b/bot/tests/test_main.py
@@ -1,0 +1,15 @@
+import importlib
+from prometheus_client import REGISTRY
+import sys
+
+
+def test_flbot_without_telegram(monkeypatch):
+    monkeypatch.delenv("TELEGRAM_API_ID", raising=False)
+    monkeypatch.delenv("TELEGRAM_API_HASH", raising=False)
+    monkeypatch.setenv("DISCORD_TOKEN", "x")
+    for collector in list(REGISTRY._collector_to_names):
+        REGISTRY.unregister(collector)
+    sys.modules.pop("bot.main", None)
+    m = importlib.import_module("bot.main")
+    bot = m.FLBot()
+    assert bot.bridge is None

--- a/bot/tests/test_telegram_bridge.py
+++ b/bot/tests/test_telegram_bridge.py
@@ -46,6 +46,13 @@ class FakeBot:
         return None
 
 
+def test_bridge_skips_client_creation_when_missing_credentials():
+    bot = FakeBot(1)
+    bridge = TelegramBridge(bot)
+    assert bridge.client is None
+    asyncio.run(bridge.start())  # should no-op without error
+
+
 def test_bridge_forwards_messages():
     bot = FakeBot(1)
     tg_client = FakeTelegramClient()

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "FetLife adapter library",
     "type": "library",
     "license": "AGPL-3.0-or-later",
-    "version": "1.3.7",
+    "version": "1.3.8",
     "require": {
         "php": "^8.2"
     },

--- a/plan.md
+++ b/plan.md
@@ -1,32 +1,24 @@
-## Repo Intake
-- Languages: Python, PHP
-- Build tools: setuptools, Composer
-- Package managers: pip, Composer
-- Entrypoints: Docker Compose services `adapter`, `bot`
-- Tests: `bash scripts/agents-verify.sh`, `make fmt`, `make check`
-- CI jobs: `release-hygiene.yml`, `release.yml`
-- Release process: bump versions in `pyproject.toml` and `composer.json`, update `CHANGELOG.md`, tag `vX.Y.Z`, publish notes from `.github/RELEASE_NOTES.md`
-
 ## Goal
-Split development dependencies from runtime and ensure tooling installs dev extras only when needed.
+Allow the Discord bot to run when Telegram credentials are absent.
 
 ## Constraints
-- Follow existing file styles.
-- Bump Python and PHP package versions together.
+- Follow existing code style and repository guidelines.
+- Bump Python and PHP versions together.
 
 ## Risks
-- Missing dev dependencies could break formatting or tests.
-- Documentation may drift from new dependency layout.
+- Conditional bridge creation may introduce attribute errors if not handled everywhere.
+- Tests might require environment isolation to simulate missing credentials.
 
 ## Test Plan
-- `bash scripts/agents-verify.sh`
 - `make fmt`
-- `pip-audit -r requirements.txt -r requirements-dev.txt`
-- `composer audit`
 - `make check`
 
 ## Semver
-Patch release (build workflow change).
+Patch release: fix optional Telegram bridge handling.
+
+## Affected Packages
+- Python package `fetlife-discord-bot`
+- PHP package `project/fetlife-discord-bot`
 
 ## Rollback
-Revert this commit.
+Revert the commit.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fetlife-discord-bot"
-version = "1.3.7"
+version = "1.3.8"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 classifiers = [


### PR DESCRIPTION
## Summary
- guard Telegram bridge creation when Telegram credentials are absent
- handle missing Telegram credentials in bridge startup
- document optional Telegram settings

## Rationale
The bot previously required Telegram credentials even when the bridge was unused, preventing startup in some deployments. This change makes the bridge optional.

## Semver
Patch release v1.3.8

## Testing
- `make fmt` *(fails: unknown flag: --rm)*
- `make check` *(fails: docker: 'compose' is not a docker command)*
- `black --check bot/main.py bot/telegram_bridge.py bot/tests/test_telegram_bridge.py bot/tests/test_main.py`
- `flake8 bot/main.py bot/telegram_bridge.py bot/tests/test_telegram_bridge.py bot/tests/test_main.py`
- `mypy bot/main.py bot/telegram_bridge.py`
- `pytest bot/tests/test_main.py bot/tests/test_telegram_bridge.py`

## Risks
- Telegram commands now error if used without credentials; further UX refinements may be needed.

## Rollback
Revert the commit.

## Packages
- `fetlife-discord-bot`
- `project/fetlife-discord-bot`


------
https://chatgpt.com/codex/tasks/task_e_689db6b36ea48332ace2ac7cc33c1d4a