### PR TITLE
chore(env): reference .env example (v1.3.9)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,10 +1,10 @@
 FETLIFE_USERNAME=your_username
 FETLIFE_PASSWORD=your_password
-CREDENTIAL_SALT=
+CREDENTIAL_SALT=example_salt
 DISCORD_TOKEN=your_token
-TELEGRAM_API_ID=
-TELEGRAM_API_HASH=
-ADAPTER_AUTH_TOKEN=
+TELEGRAM_API_ID=123456
+TELEGRAM_API_HASH=your_api_hash
+ADAPTER_AUTH_TOKEN=adapter_token
 ADAPTER_BASE_URL=http://adapter:8000
 
 # Database connection
@@ -13,10 +13,10 @@ DB_PORT=5432
 DB_NAME=fetlife_bot
 DB_USER=bot_user
 DB_PASSWORD=bot_password
-DATABASE_URL=
+DATABASE_URL=postgresql://bot_user:bot_password@localhost:5432/fetlife_bot
 
 # Proxy settings (optional)
-FETLIFE_PROXY=
+FETLIFE_PROXY=http://proxy:8080
 FETLIFE_PROXY_TYPE=CURLPROXY_HTTP
-FETLIFE_PROXY_USERNAME=
-FETLIFE_PROXY_PASSWORD=
+FETLIFE_PROXY_USERNAME=proxy_user
+FETLIFE_PROXY_PASSWORD=proxy_password

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+## [1.3.9] - 2025-08-14
+### Changed
+- Provide `.env.example` template with placeholder values and reference it in README and setup script.
+
 ## [1.3.8] - 2025-08-14
 ### Fixed
 - Allow bot to run without Telegram credentials.

--- a/README.markdown
+++ b/README.markdown
@@ -14,7 +14,7 @@ The `bot/` directory contains a Python application using `discord.py` that relay
 
 ### Environment Variables
 
-The `.env` file supports these keys:
+Copy `.env.example` to `.env` and fill in your values. The `.env` file supports these keys:
 
 - `FETLIFE_USERNAME` – FetLife account username.
 - `FETLIFE_PASSWORD` – FetLife account password.

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "FetLife adapter library",
     "type": "library",
     "license": "AGPL-3.0-or-later",
-    "version": "1.3.8",
+    "version": "1.3.9",
     "require": {
         "php": "^8.2"
     },

--- a/plan.md
+++ b/plan.md
@@ -1,20 +1,20 @@
 ## Goal
-Allow the Discord bot to run when Telegram credentials are absent.
+Provide `.env.example` template and reference it in docs and setup script.
 
 ## Constraints
 - Follow existing code style and repository guidelines.
 - Bump Python and PHP versions together.
 
 ## Risks
-- Conditional bridge creation may introduce attribute errors if not handled everywhere.
-- Tests might require environment isolation to simulate missing credentials.
+- Sample values may mislead users if defaults change.
+- Setup script copy might overwrite existing config unintentionally.
 
 ## Test Plan
 - `make fmt`
 - `make check`
 
 ## Semver
-Patch release: fix optional Telegram bridge handling.
+Patch release: documentation and setup improvements.
 
 ## Affected Packages
 - Python package `fetlife-discord-bot`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fetlife-discord-bot"
-version = "1.3.8"
+version = "1.3.9"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 classifiers = [

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -24,8 +24,13 @@ write_env() {
 
 # Ensure .env exists
 if [[ ! -f "$ENV_FILE" ]]; then
-  touch "$ENV_FILE"
-  echo "Created $ENV_FILE"
+  if [[ -f ".env.example" ]]; then
+    cp .env.example "$ENV_FILE"
+    echo "Copied .env.example to $ENV_FILE"
+  else
+    touch "$ENV_FILE"
+    echo "Created $ENV_FILE"
+  fi
 fi
 
 # Gather credentials and DB parameters


### PR DESCRIPTION
## Summary
- add `.env.example` with placeholder values and document in README
- setup script bootstraps missing `.env` from `.env.example`
- bump patch version to 1.3.9

## Rationale
Clarifies environment configuration and simplifies setup by providing a template and automated copy.

## Semver Impact
Patch release: documentation and setup improvements.

## Test Evidence
- `make fmt` *(fails: unknown flag --rm)*
- `make check` *(fails: docker: 'compose' is not a docker command)*

## Risks
- Sample values may become outdated or overwrite existing `.env` when copied.

## Rollback
Revert the commit.

## Affected Packages
- `fetlife-discord-bot`
- `project/fetlife-discord-bot`


------
https://chatgpt.com/codex/tasks/task_e_689db8f7b60c83329731792b634873d2