### PR TITLE
fix(bot): reschedule stored subscriptions on startup (v1.3.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+## [1.3.12] - 2025-08-16
+### Fixed
+- Reschedule stored subscriptions on startup so they persist across restarts.
+
 ## [1.3.11] - 2025-08-15
 ### Changed
 - Rename `Agents.md` to `AGENTS.md` and update references.

--- a/bot/main.py
+++ b/bot/main.py
@@ -205,6 +205,22 @@ class FLBot(commands.Bot):
         self.last_poll = 0.0
 
     async def setup_hook(self) -> None:
+        channels = [c.id for c in self.db.query(models.Channel.id).all()]
+        for channel_id in channels:
+            for sub_id, sub_type, _target, _acct in storage.list_subscriptions(
+                self.db, channel_id
+            ):
+                self.scheduler.add_job(
+                    poll_adapter,
+                    args=[
+                        self.db,
+                        sub_id,
+                        {"interval": 60, "type": sub_type},
+                    ],
+                    id=str(sub_id),
+                    replace_existing=True,
+                    run_date=datetime.utcnow() + timedelta(seconds=1),
+                )
         self.scheduler.start()
 
 

--- a/bot/tests/test_subscription_persistence.py
+++ b/bot/tests/test_subscription_persistence.py
@@ -1,0 +1,40 @@
+import asyncio
+import importlib
+import sys
+from pathlib import Path
+
+from prometheus_client import REGISTRY
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from bot import storage
+
+
+def _reload_main():
+    for collector in list(REGISTRY._collector_to_names):
+        REGISTRY.unregister(collector)
+    sys.modules.pop("bot.main", None)
+    return importlib.import_module("bot.main")
+
+
+def test_subscriptions_persist_across_restarts(tmp_path, monkeypatch):
+    db_file = tmp_path / "test.db"
+    db_url = f"sqlite:///{db_file}"
+    monkeypatch.setenv("DATABASE_URL", db_url)
+    monkeypatch.setenv("DISCORD_TOKEN", "x")
+
+    db = storage.init_db(db_url)
+    sub_id = storage.add_subscription(db, 1, "events", "cities/1")
+    db.close()
+
+    main = _reload_main()
+    bot1 = main.FLBot()
+    main.bot = bot1
+    asyncio.run(bot1.setup_hook())
+    assert str(sub_id) in [job.id for job in bot1.scheduler.get_jobs()]
+
+    main = _reload_main()
+    bot2 = main.FLBot()
+    main.bot = bot2
+    asyncio.run(bot2.setup_hook())
+    assert str(sub_id) in [job.id for job in bot2.scheduler.get_jobs()]

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "FetLife adapter library",
     "type": "library",
     "license": "AGPL-3.0-or-later",
-    "version": "1.3.11",
+    "version": "1.3.12",
     "require": {
         "php": "^8.2"
     },

--- a/plan.md
+++ b/plan.md
@@ -1,22 +1,25 @@
 ## Goal
-Clarify deployment instructions for running the bot continuously.
+Load stored subscriptions on bot startup so they persist across restarts and add a regression test.
 
 ## Constraints
-- Keep documentation consistent with scripts and docker-compose configuration.
+- Follow AGENTS.md: run make fmt and make check before committing.
+- Keep versioning and changelog consistent.
 
 ## Risks
-- Inaccurate guidance could lead to failed deployments.
+- Scheduler jobs may execute during tests and call external services.
 
 ## Test Plan
 - `make fmt`
 - `make check`
+- `pip-audit -r requirements.txt`
 - `bash scripts/agents-verify.sh`
 
 ## Semver
-Patch release: documentation update.
+Patch release: internal bug fix.
 
 ## Affected Packages
-- None
+- Python bot
+- PHP adapter (version bump only)
 
 ## Rollback
-Revert the commit.
+Revert the commit and reset versions.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fetlife-discord-bot"
-version = "1.3.11"
+version = "1.3.12"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 classifiers = [


### PR DESCRIPTION
## Summary
- reschedule persisted subscriptions on startup to survive restarts
- add regression test for subscription persistence
- bump version to v1.3.12

## Rationale
Restoring jobs from storage on startup prevents lost subscriptions after bot restarts.

## Semver
Patch release: backwards compatible bug fix.

## Testing
- `make fmt` *(fails: docker not installed)*
- `make check` *(fails: docker not installed)*
- `black bot/main.py bot/tests/test_subscription_persistence.py`
- `flake8 bot`
- `mypy bot`
- `pytest bot/tests/test_subscription_persistence.py`
- `pip-audit -r requirements.txt`
- `bash scripts/agents-verify.sh` *(fails: docker not installed)*

## Risk
Low. Changes confined to startup scheduling logic and tests.

## Rollback
Revert the commits and drop version 1.3.12.


------
https://chatgpt.com/codex/tasks/task_e_68a048ef20d4833283ec7eb658c49bd7