### PR TITLE
chore(docker): pin Postgres image digest (v1.3.13)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -394,4 +394,5 @@ Releases are tagged from `main` and publish notes from `.github/RELEASE_NOTES.md
 Adapter and bot Dockerfiles use multi-stage builds with base images pinned to immutable digests for reproducible builds and smaller attack surfaces:
 - `php:8.2-cli@sha256:304cfb487bbe9b2ce5a933f6e5848e0248bff1fbb0d5ee36cec845f4a34f4fb1`
 - `python:3.11-slim@sha256:0ce77749ac83174a31d5e107ce0cfa6b28a2fd6b0615e029d9d84b39c48976ee`
+- `postgres:15@sha256:0de3e43bbb424d5fb7ca1889150f8e1b525d6c9fbaf9df6d853dcbc2ed5ffa1e`
 Builder stages install toolchains and dependencies; runtime stages contain only application code and installed packages. Update digests alongside security releases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+## [1.3.13] - 2025-08-16
+### Security
+- Pin Postgres image to immutable digest in Docker Compose.
+
 ## [1.3.12] - 2025-08-16
 ### Fixed
 - Reschedule stored subscriptions on startup so they persist across restarts.

--- a/README.markdown
+++ b/README.markdown
@@ -9,7 +9,8 @@ The `bot/` directory contains a Python application using `discord.py` that relay
 ### Docker Compose Quick Start
 
 1. `bash scripts/install.sh` and select **Install**. This creates `.venv` and installs runtime and development dependencies.
-2. `docker compose up -d` to launch the adapter, bot, and database.
+2. `docker compose up -d` to launch the adapter, bot, and database. The `db` service pins
+   `postgres:15` to digest `sha256:0de3e43bbb424d5fb7ca1889150f8e1b525d6c9fbaf9df6d853dcbc2ed5ffa1e` for reproducible builds.
 3. Generate an invite link from the [Discord Developer Portal](https://discord.com/developers/applications), invite the bot to your server, then run `/fl login` to verify adapter authentication, `/fl subscribe events location:cities/5898 min_attendees:10`, `/fl subscribe group_posts group:1`, `/fl subscribe messages inbox`, `/fl list`, and `/fl test <id>` in Discord.
 
 ### Environment Variables

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "FetLife adapter library",
     "type": "library",
     "license": "AGPL-3.0-or-later",
-    "version": "1.3.12",
+    "version": "1.3.13",
     "require": {
         "php": "^8.2"
     },

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.9'
 
 services:
   db:
-    image: postgres:15
+    image: postgres:15@sha256:0de3e43bbb424d5fb7ca1889150f8e1b525d6c9fbaf9df6d853dcbc2ed5ffa1e
     restart: unless-stopped
     env_file: .env
     environment:

--- a/plan.md
+++ b/plan.md
@@ -1,12 +1,13 @@
 ## Goal
-Load stored subscriptions on bot startup so they persist across restarts and add a regression test.
+Pin Postgres image digest in Docker Compose and document the change.
 
 ## Constraints
 - Follow AGENTS.md: run make fmt and make check before committing.
+- Run pip-audit and agents-verify.
 - Keep versioning and changelog consistent.
 
 ## Risks
-- Scheduler jobs may execute during tests and call external services.
+- Digest may become outdated, requiring refreshes.
 
 ## Test Plan
 - `make fmt`
@@ -15,11 +16,12 @@ Load stored subscriptions on bot startup so they persist across restarts and add
 - `bash scripts/agents-verify.sh`
 
 ## Semver
-Patch release: internal bug fix.
+Patch release: security hardening.
 
 ## Affected Packages
+- Docker Compose configuration (db service)
 - Python bot
 - PHP adapter (version bump only)
 
 ## Rollback
-Revert the commit and reset versions.
+Revert commit and reset versions and digest.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fetlife-discord-bot"
-version = "1.3.12"
+version = "1.3.13"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 classifiers = [


### PR DESCRIPTION
## Summary
- pin Postgres image to immutable digest in docker-compose
- document Postgres digest in AGENTS and README
- bump version to v1.3.13

## Rationale
Locks database image to a specific build for reproducible and secure deployments.

## Semver
Patch release: dependency pinning and docs.

## Testing
- `make fmt` *(fails: docker not found)*
- `make check` *(fails: docker not found)*
- `pip-audit -r requirements.txt`
- `bash scripts/agents-verify.sh`

## Risk
Low. A digest typo would prevent container startup.

## Rollback
Revert commit and restore previous versions and image tag.

## Packages
- python bot
- php adapter

------
https://chatgpt.com/codex/tasks/task_e_68a04c4488b88332a4c84ec45929a083