### PR TITLE
feat(storage): cache event and RSVP data (1.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented here.
 
 ### Added
 - Pause polling after repeated adapter failures with `/fl health` status and manual resume.
+- Cache events, profiles, and RSVP records during polling.
 
 ### Security
 - Run `pip-audit` and `composer audit` in `make check` and release-hygiene workflow.

--- a/README.markdown
+++ b/README.markdown
@@ -42,6 +42,12 @@ When using Docker Compose:
 docker compose run --rm bot alembic upgrade head
 ```
 
+### Cache Behavior
+
+Events, profiles, and RSVP statuses are cached in the database. During polling, the bot
+upserts these records before relaying messages to Discord, enabling deduplication and
+future features. Use `/fl purge` to clear cached data when needed.
+
 ### Health Checks
 
 - Adapter: `GET http://localhost:8000/healthz` for liveness and `GET http://localhost:8000/metrics` for Prometheus metrics.

--- a/bot/tests/test_attendees_subscription.py
+++ b/bot/tests/test_attendees_subscription.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from bot import main, storage  # noqa: E402
+from bot import main, storage, models  # noqa: E402
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -35,3 +35,7 @@ def test_poll_attendees_updates_cursor_and_sends_message():
     channel.send.assert_called_once()
     _, ids = storage.get_cursor(db, sub_id)
     assert ids == [str(items[0]["id"])]
+    profile = db.query(models.Profile).filter_by(fl_id=str(items[0]["id"])).one()
+    rsvp = db.query(models.RSVP).filter_by(profile_fl_id=profile.fl_id).one()
+    event = db.query(models.Event).filter_by(fl_id="1").one()
+    assert rsvp.event_id == event.id

--- a/bot/tests/test_poll_adapter.py
+++ b/bot/tests/test_poll_adapter.py
@@ -62,6 +62,22 @@ def test_poll_adapter_dedupes_and_updates_cursor():
     assert channel.send.call_count == 1
 
 
+def test_poll_adapter_caches_events():
+    db = storage.init_db("sqlite:///:memory:")
+    sub_id = storage.add_subscription(db, 1, "events", "cities/1")
+    items = [
+        {
+            "id": "1",
+            "title": "t",
+            "link": "l",
+            "time": "2025-01-01T00:00:00",
+        }
+    ]
+    asyncio.run(run_poll(db, sub_id, items, {"interval": 60}))
+    event = db.query(models.Event).filter_by(fl_id="1").one()
+    assert event.title == "t"
+
+
 def test_poll_adapter_backoff_on_http_error():
     db = storage.init_db("sqlite:///:memory:")
     sub_id = storage.add_subscription(db, 1, "events", "cities/1")


### PR DESCRIPTION
## Summary
- add helpers to upsert Event, Profile, and RSVP records
- populate caches during polling before relaying
- document cache behavior in README

## Rationale and Context
Caching key entities allows the bot to deduplicate relays and support future features that rely on stored event, profile, and RSVP data.

## SemVer Justification
Minor: adds backward-compatible functionality.

## Test Evidence
- `make fmt` *(fails: unknown flag: --rm)*
- `make check` *(fails: docker: 'compose' is not a docker command)*
- `black bot/main.py bot/storage.py bot/tests/test_attendees_subscription.py bot/tests/test_poll_adapter.py`
- `pytest bot/tests/test_poll_adapter.py bot/tests/test_attendees_subscription.py`

## Risk Assessment and Rollback Plan
Changes affect polling and database writes; revert commit if unexpected caching behavior or database issues arise.

## Affected Packages
- bot

## Checklist
- [x] Intake analysis complete
- [x] Plan reviewed and approved
- [ ] Version files updated
- [x] CHANGELOG.md updated
- [ ] CI pipeline passing
- [x] Documentation synchronized
- [ ] Security audit complete
- [ ] Release tags prepared

------
https://chatgpt.com/codex/tasks/task_e_68a071cf5c8483329d64ea0839f6fa85