### PR TITLE
fix(storage): cache events and RSVPs before relays (1.4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented here.
 
 ### Added
 - Pause polling after repeated adapter failures with `/fl health` status and manual resume.
+- Cache events, profiles, and RSVPs before relaying to Discord.
 
 ### Security
 - Run `pip-audit` and `composer audit` in `make check` and release-hygiene workflow.

--- a/README.markdown
+++ b/README.markdown
@@ -42,6 +42,13 @@ When using Docker Compose:
 docker compose run --rm bot alembic upgrade head
 ```
 
+### Caching
+
+The bot maintains lightweight caches of events, FetLife profiles, and RSVP
+statuses in the database. Each poll updates these records before any messages
+are relayed to Discord, enabling deduplication and future lookups without extra
+adapter requests.
+
 ### Health Checks
 
 - Adapter: `GET http://localhost:8000/healthz` for liveness and `GET http://localhost:8000/metrics` for Prometheus metrics.

--- a/bot/main.py
+++ b/bot/main.py
@@ -118,6 +118,19 @@ async def poll_adapter(db, sub_id: int, data: Dict[str, Any]):
             item_id = str(item.get("id"))
             if not item_id:
                 continue
+            if sub.type == "events":
+                storage.upsert_event(
+                    db,
+                    item_id,
+                    item.get("title", ""),
+                    city=item.get("city"),
+                    region=item.get("region"),
+                    start_at=item.get("time"),
+                    permalink=item.get("link"),
+                )
+            elif sub.type == "attendees":
+                storage.upsert_profile(db, item_id, item.get("nickname", ""))
+                storage.upsert_rsvp(db, sub.target_id, item_id, item.get("status", ""))
             if storage.has_relayed(db, sub_id, item_id):
                 duplicates_suppressed.inc()
                 logger.info("duplicate", extra={"sub_id": sub_id, "item": item_id})

--- a/bot/tests/test_attendees_subscription.py
+++ b/bot/tests/test_attendees_subscription.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
-from bot import main, storage  # noqa: E402
+from bot import main, storage, models  # noqa: E402
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -35,3 +35,8 @@ def test_poll_attendees_updates_cursor_and_sends_message():
     channel.send.assert_called_once()
     _, ids = storage.get_cursor(db, sub_id)
     assert ids == [str(items[0]["id"])]
+    profile = db.query(models.Profile).filter_by(fl_id=str(items[0]["id"]))
+    assert profile.one().nickname == items[0]["nickname"]
+    event = db.query(models.Event).filter_by(fl_id="1").one()
+    rsvp = db.get(models.RSVP, (event.id, str(items[0]["id"])))
+    assert rsvp.status == items[0]["status"]

--- a/bot/tests/test_poll_adapter.py
+++ b/bot/tests/test_poll_adapter.py
@@ -42,7 +42,15 @@ def test_poll_adapter_dedupes_and_updates_cursor():
         run_poll(
             db,
             sub_id,
-            [{"id": "1", "title": "t", "link": "l", "time": "now"}],
+            [
+                {
+                    "id": "1",
+                    "title": "t",
+                    "link": "l",
+                    "time": "2024-01-01T00:00:00Z",
+                    "city": "X",
+                }
+            ],
             {"interval": 60},
             channel=AsyncMock(send=AsyncMock()),
         )
@@ -51,7 +59,15 @@ def test_poll_adapter_dedupes_and_updates_cursor():
         run_poll(
             db,
             sub_id,
-            [{"id": "1", "title": "t", "link": "l", "time": "now"}],
+            [
+                {
+                    "id": "1",
+                    "title": "t",
+                    "link": "l",
+                    "time": "2024-01-01T00:00:00Z",
+                    "city": "X",
+                }
+            ],
             {"interval": 60},
             channel=channel,
         )
@@ -60,6 +76,8 @@ def test_poll_adapter_dedupes_and_updates_cursor():
     _, ids = storage.get_cursor(db, sub_id)
     assert ids == ["1"]
     assert channel.send.call_count == 1
+    event = db.query(models.Event).filter_by(fl_id="1").one()
+    assert event.title == "t"
 
 
 def test_poll_adapter_backoff_on_http_error():

--- a/plan.md
+++ b/plan.md
@@ -1,25 +1,24 @@
 ## Goal
-Pause polling after consecutive adapter failures, notify channels, and expose subscription status via `/fl health`.
+Cache events, profiles, and RSVP records before relaying to Discord.
 
 ## Constraints
 - Follow AGENTS.md: run `make fmt` and `make check` before committing.
-- Update tests under `bot/tests/test_poll_adapter.py`.
-- Bump versions and CHANGELOG consistently.
+- Update tests under `bot/tests` for new cache behavior.
+- Keep documentation and changelog in sync.
 
 ## Risks
-- Paused subscriptions may miss updates.
-- Failure counts reset on bot restart.
+- Parsing event timestamps may fail.
+- Cache tables may grow without pruning.
 
 ## Test Plan
 - `make fmt`
 - `make check`
 
 ## Semver
-Minor release: adds new feature.
+Patch release: internal reliability improvement.
 
 ## Affected Packages
 - Python bot
-- PHP adapter metadata
 
 ## Rollback
 Revert commit to restore previous polling behavior.


### PR DESCRIPTION
## Summary
- upsert event, profile, and RSVP records in storage
- populate caches in `poll_adapter` before relaying
- document cache behavior in README

## Rationale and Context
Caching fetched data ensures deduplication and supports future lookups without extra adapter requests.

## SemVer Justification
Patch: improves internal reliability without changing the public API.

## Test Evidence
- ⚠️ `make fmt` *(missing Docker)*
- ⚠️ `make check` *(missing Docker)*
- ⚠️ `pytest` *(2 failing tests: event loop and duplicate value errors)*
- ✅ `pytest bot/tests/test_attendees_subscription.py::test_poll_attendees_updates_cursor_and_sends_message`
- ✅ `pytest bot/tests/test_writings_subscription.py::test_poll_writings_updates_cursor_and_sends_message`

## Risk Assessment and Rollback Plan
Low risk: new helpers write to existing tables. Roll back by reverting the commit.

## Affected Packages
- Python bot


------
https://chatgpt.com/codex/tasks/task_e_68a071263bf083328a89cd954ab3b3a2