### PR TITLE
chore(compose): add service health checks (patch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented here.
 ### Added
 - Pause polling after repeated adapter failures with `/fl health` status and manual resume.
 - Cache events, profiles, and RSVP records during polling.
+- Docker healthchecks for bot and adapter services with `make health` helper.
 
 ### Changed
 - Install Python dependencies from `requirements.lock` for reproducible builds.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: check fmt
+.PHONY: check fmt health
 
 fmt:
 	docker compose run --rm bot sh -c "pip install -r requirements-dev.txt && black bot"
@@ -11,3 +11,7 @@ check:
 	docker compose -f tests/docker-compose.test.yml down || true
 	docker run --rm -v $(PWD):/app composer audit
 	docker compose run --rm adapter vendor/bin/phpunit
+
+health:
+	docker compose exec bot curl -f http://localhost:8000/ready
+	docker compose exec adapter curl -f http://localhost:8000/healthz

--- a/README.markdown
+++ b/README.markdown
@@ -50,6 +50,8 @@ future features. Use `/fl purge` to clear cached data when needed.
 
 ### Health Checks
 
+Docker Compose declares health checks for both services using these endpoints. After the stack is running, `make health` executes them manually.
+
 - Adapter: `GET http://localhost:8000/healthz` for liveness and `GET http://localhost:8000/metrics` for Prometheus metrics.
 - Bot: `GET http://localhost:8000/ready` for readiness and `GET http://localhost:8000/metrics` for Prometheus metrics.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,11 @@ services:
     ports:
       - "8000:8000"
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/healthz"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
 
   bot:
     build:
@@ -40,6 +45,11 @@ services:
       - db
     command: ["python3", "-m", "bot.main"]
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/ready"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
 
 volumes:
   db_data:


### PR DESCRIPTION
## Summary
- add Docker healthchecks for bot and adapter services
- expose new `make health` target and document health checks

## Rationale and Context
Adds container health probes so Docker can detect when either service is unhealthy and provides a simple way to run the checks manually.

## SemVer Justification
Patch: documentation and operational tooling updates without API changes.

## Test Evidence
- `make fmt` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*
- `make check` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

## Risk Assessment and Rollback Plan
Low risk configuration and documentation changes. If issues arise, revert this commit to remove the healthchecks and make target.

## Affected Packages
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68a07b3eddb88332a0e30bd60f9b40c5