### PR TITLE
feat(adapter): document adapter API via OpenAPI (1.4.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ Edit
                                    \-> [Metrics/Logs]
 Discord Bot: Handles commands, subscriptions, formatting, and dispatch.
 
-FetLife Adapter: Thin PHP service wrapping libFetLife (CLI or HTTP). Encapsulates login, pagination, and standardized JSON responses. Requires an `Authorization: Bearer` token matching `ADAPTER_AUTH_TOKEN`.
+FetLife Adapter: Thin PHP service wrapping libFetLife (CLI or HTTP). Encapsulates login, pagination, and standardized JSON responses. Requires an `Authorization: Bearer` token matching `ADAPTER_AUTH_TOKEN`. HTTP endpoints are documented in [`adapter/openapi.yaml`](adapter/openapi.yaml) and served from `/openapi.yaml`.
 
 Storage: SQLite/Postgres (prod) for subscriptions, seen items, cursors, and audit logs.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented here.
 - Pause polling after repeated adapter failures with `/fl health` status and manual resume.
 - Cache events, profiles, and RSVP records during polling.
 - Docker healthchecks for bot and adapter services with `make health` helper.
+- OpenAPI specification and `/openapi.yaml` route for the adapter.
 
 ### Changed
 - Install Python dependencies from `requirements.lock` for reproducible builds.

--- a/README.markdown
+++ b/README.markdown
@@ -319,44 +319,9 @@ It reads credentials from environment variables (`FETLIFE_USERNAME`, `FETLIFE_PA
 All requests must include an `Authorization: Bearer` token matching `ADAPTER_AUTH_TOKEN`.
 
 ### OpenAPI
-
-```yaml
-openapi: 3.0.0
-info:
-  title: FetLife Adapter API
-  version: 1.0.0
-paths:
-  /login:
-    post:
-      summary: Authenticate and store session
-      responses:
-        '200': { description: Logged in }
-  /events:
-    get:
-      summary: List upcoming events for a location
-      parameters:
-        - in: query
-          name: location
-          required: true
-          schema: { type: string }
-      responses:
-        '200': { description: Array of events }
-  /events/{id}:
-    get:
-      summary: Fetch event details
-      responses:
-        '200': { description: Event }
-  /users/{id}/writings:
-    get:
-      summary: List writings for a user
-      responses:
-        '200': { description: Writings }
-  /groups/{id}/posts:
-    get:
-      summary: List posts in a group
-      responses:
-        '200': { description: Posts }
-```
+The adapter's HTTP API is documented in
+[adapter/openapi.yaml](adapter/openapi.yaml), served at
+`/openapi.yaml` when the service is running.
 
 ## Contributing
 

--- a/adapter/openapi.yaml
+++ b/adapter/openapi.yaml
@@ -1,0 +1,266 @@
+openapi: 3.0.3
+info:
+  title: FetLife Adapter API
+  version: 0.1.0
+  description: |
+    HTTP API for the FetLife adapter service wrapping libFetLife.
+servers:
+  - url: /
+components:
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+security:
+  - bearerAuth: []
+paths:
+  /login:
+    post:
+      summary: Authenticate to FetLife and store a session
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                username:
+                  type: string
+                password:
+                  type: string
+      responses:
+        '200':
+          description: Login succeeded
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+                    example: ok
+        '400':
+          description: Missing credentials
+        '401':
+          description: Login failed
+  /events:
+    get:
+      summary: List upcoming events for a location
+      parameters:
+        - in: query
+          name: location
+          schema:
+            type: string
+          required: true
+        - in: query
+          name: account
+          schema:
+            type: string
+          required: false
+      responses:
+        '200':
+          description: Array of events
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id:
+                      type: integer
+                    title:
+                      type: string
+                    link:
+                      type: string
+                      format: uri
+                    time:
+                      type: string
+                      format: date-time
+        '401':
+          description: Not authenticated
+  /events/{id}:
+    get:
+      summary: Fetch event details
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+        - in: query
+          name: account
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Event details
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: {type: integer}
+                  title: {type: string}
+                  link: {type: string, format: uri}
+                  start: {type: string, format: date-time}
+                  end: {type: string, format: date-time}
+        '401':
+          description: Not authenticated
+  /events/{id}/attendees:
+    get:
+      summary: List attendees for an event
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+        - in: query
+          name: pages
+          schema:
+            type: integer
+          required: false
+        - in: query
+          name: account
+          schema:
+            type: string
+          required: false
+      responses:
+        '200':
+          description: Array of attendees
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: {type: integer}
+                    nickname: {type: string}
+                    status: {type: string}
+                    comment: {type: string, nullable: true}
+        '401':
+          description: Not authenticated
+  /users/{id}/writings:
+    get:
+      summary: List writings for a user
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+        - in: query
+          name: account
+          schema:
+            type: string
+          required: false
+      responses:
+        '200':
+          description: Array of writings
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: {type: integer}
+                    title: {type: string}
+                    link: {type: string, format: uri}
+                    published: {type: string, format: date-time}
+        '401':
+          description: Not authenticated
+  /groups/{id}/posts:
+    get:
+      summary: List recent posts in a group
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: integer
+          required: true
+        - in: query
+          name: account
+          schema:
+            type: string
+          required: false
+      responses:
+        '200':
+          description: Array of posts
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: {type: integer}
+                    title: {type: string}
+                    link: {type: string, format: uri}
+                    published: {type: string, format: date-time, nullable: true}
+        '401':
+          description: Not authenticated
+  /messages:
+    get:
+      summary: List recent direct messages
+      parameters:
+        - in: query
+          name: account
+          schema:
+            type: string
+          required: false
+      responses:
+        '200':
+          description: Array of messages
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: object
+                  properties:
+                    id: {type: integer}
+                    sender: {type: string}
+                    text: {type: string}
+                    sent: {type: string, format: date-time, nullable: true}
+        '401':
+          description: Not authenticated
+  /healthz:
+    get:
+      summary: Liveness probe
+      security: []
+      responses:
+        '200':
+          description: Service is running
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status:
+                    type: string
+  /metrics:
+    get:
+      summary: Prometheus metrics
+      security: []
+      responses:
+        '200':
+          description: Metrics output
+          content:
+            text/plain:
+              schema:
+                type: string
+  /openapi.yaml:
+    get:
+      summary: This OpenAPI document
+      security: []
+      responses:
+        '200':
+          description: OpenAPI YAML
+          content:
+            application/yaml:
+              schema:
+                type: string

--- a/adapter/public/index.php
+++ b/adapter/public/index.php
@@ -21,7 +21,7 @@ $token = $_ENV['ADAPTER_AUTH_TOKEN'] ?? null;
 
 $app->add(function ($request, $handler) use ($token) {
     $path = $request->getUri()->getPath();
-    if (in_array($path, ['/healthz', '/metrics'])) {
+    if (in_array($path, ['/healthz', '/metrics', '/openapi.yaml'])) {
         return $handler->handle($request);
     }
     $auth = $request->getHeaderLine('Authorization');
@@ -293,6 +293,12 @@ $app->get('/healthz', function ($request, $response) {
 $app->get('/metrics', function ($request, $response) {
     $response->getBody()->write(metrics_text());
     return $response->withHeader('Content-Type', 'text/plain; version=0.0.4');
+});
+
+$app->get('/openapi.yaml', function ($request, $response) {
+    $spec = file_get_contents(__DIR__ . '/../openapi.yaml');
+    $response->getBody()->write($spec);
+    return $response->withHeader('Content-Type', 'application/yaml');
 });
 
 $app->run();


### PR DESCRIPTION
## Summary
- add OpenAPI spec describing adapter HTTP endpoints
- serve spec at `/openapi.yaml`
- link adapter spec in docs

## Rationale and Context
Provides machine-readable description of adapter API and exposes it for clients.

## SemVer Justification
feat: introduces a new documented endpoint and spec.

## Test Evidence
- `make fmt` *(fails: unknown flag: --rm)*
- `make check` *(fails: docker: 'compose' is not a docker command)*

## Risk Assessment and Rollback Plan
Low risk documentation and routing changes. Roll back by removing new route and spec file.

## Affected Packages
- adapter


------
https://chatgpt.com/codex/tasks/task_e_68a07f0dfdf0833287cbb4b3ee74fbde