### PR TITLE
docs(adapter): document reverse proxy TLS requirements (1.3.15)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,10 @@ Data Minimization: Post excerpts and links; avoid relaying sensitive profile det
 
 GDPR/UK: Treat relayed content as transient notification; provide deletion controls (purge caches, forget channel data).
 
+TLS: Terminate HTTPS at a reverse proxy (e.g., Caddy or Nginx) and forward `Host`,
+`X-Forwarded-For`, and `X-Forwarded-Proto` headers. Set `ADAPTER_BASE_URL`
+to the external `https://` URL.
+
 Rate Limiting: Token bucket at the adapter + bot layers. Exponential backoff on 4xx/5xx.
 
 5) Discord Commands (Slash)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented here.
 - Cache events, profiles, and RSVP records during polling.
 - Docker healthchecks for bot and adapter services with `make health` helper.
 - OpenAPI specification and `/openapi.yaml` route for the adapter.
+- Document running the adapter behind an HTTPS reverse proxy and note TLS expectations.
 
 ### Changed
 - Install Python dependencies from `requirements.lock` for reproducible builds.

--- a/README.markdown
+++ b/README.markdown
@@ -323,6 +323,42 @@ The adapter's HTTP API is documented in
 [adapter/openapi.yaml](adapter/openapi.yaml), served at
 `/openapi.yaml` when the service is running.
 
+### HTTPS Reverse Proxy
+
+The adapter only serves HTTP on port `8000`. For public access, place it
+behind a TLS-terminating reverse proxy such as Caddy or Nginx. Forward the
+`Host`, `X-Forwarded-For`, and `X-Forwarded-Proto` headers so the service can
+generate correct URLs and logs. The bot should then set
+`ADAPTER_BASE_URL` to the external HTTPS address, for example:
+
+```
+ADAPTER_BASE_URL=https://adapter.example.com
+```
+
+**Caddy**
+
+```Caddyfile
+adapter.example.com {
+    reverse_proxy 127.0.0.1:8000
+}
+```
+
+**Nginx**
+
+```nginx
+server {
+    listen 443 ssl;
+    server_name adapter.example.com;
+
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+```
+
 ## Contributing
 
 Pull requests are welcome. Please:

--- a/plan.md
+++ b/plan.md
@@ -1,24 +1,23 @@
 ## Goal
-Install Python dependencies from requirements.lock in Docker build and install script, and document lock usage.
+Document how to run the adapter behind an HTTPS reverse proxy and note TLS expectations in the development spec.
 
 ## Constraints
 - Follow AGENTS.md: run `make fmt` and `make check` before committing.
-- Update `bot/Dockerfile` and `scripts/install.sh` to use `requirements.lock`.
-- Document lock file usage in `AGENTS.md` and `CHANGELOG.md`.
+- Update README.markdown, AGENTS.md, and CHANGELOG.md.
 
 ## Risks
-- Outdated lock file may cause installation failures.
-- Divergence between `requirements.lock` and requirements files could break builds.
+- Misconfigured proxy headers could break authentication.
+- Inconsistent documentation may confuse deployers.
 
 ## Test Plan
 - `make fmt`
 - `make check`
 
 ## Semver
-Patch release: build and documentation changes only.
+Patch release: documentation-only changes.
 
 ## Affected Packages
-- Python bot
+- Documentation
 
 ## Rollback
-Revert commit to restore previous installation behavior.
+Revert the commit to remove documentation changes.


### PR DESCRIPTION
## Summary
- document HTTPS reverse proxy setup for the adapter and mention ADAPTER_BASE_URL and headers
- note TLS expectations in development spec
- outline plan for reverse proxy docs

## Rationale and Context
Running the adapter behind a TLS-terminating proxy is common and needed documentation.

## SemVer Justification
Patch – documentation only.

## Test Evidence
- `make fmt` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*
- `make check` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

## Risk Assessment and Rollback Plan
Low risk: documentation changes only. Revert commit to roll back.

## Affected Packages
- documentation


------
https://chatgpt.com/codex/tasks/task_e_68a0805fcaa48332ae9f558348871536