### PR TITLE
perf(db): index frequent lookup columns (patch)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -363,6 +363,7 @@ One feature per PR; include tests and docs updates.
 No secrets in code or logs.
 
 Run `make fmt` for Black formatting and `make check` (formatting check, lint, type checking, tests, schema) before PR.
+Run database migrations after pulling updates: `alembic upgrade head`.
 
 Follow semantic commits and Conventional Changelog.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented here.
 - Docker healthchecks for bot and adapter services with `make health` helper.
 - OpenAPI specification and `/openapi.yaml` route for the adapter.
 - Document running the adapter behind an HTTPS reverse proxy and note TLS expectations.
+- Index frequent lookup columns for faster database queries.
 
 ### Changed
 - Install Python dependencies from `requirements.lock` for reproducible builds.

--- a/alembic/versions/0004_add_lookup_indexes.py
+++ b/alembic/versions/0004_add_lookup_indexes.py
@@ -1,0 +1,21 @@
+"""Add indexes for frequent lookups"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0004_add_lookup_indexes"
+down_revision = "0003_prefix_sha256_hashes"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index("ix_subscriptions_channel_id", "subscriptions", ["channel_id"])
+    op.create_index("ix_relay_log_subscription_id", "relay_log", ["subscription_id"])
+    op.create_index("ix_relay_log_item_id", "relay_log", ["item_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_relay_log_item_id", table_name="relay_log")
+    op.drop_index("ix_relay_log_subscription_id", table_name="relay_log")
+    op.drop_index("ix_subscriptions_channel_id", table_name="subscriptions")

--- a/bot/models.py
+++ b/bot/models.py
@@ -40,7 +40,13 @@ class Account(Base):
 class Subscription(Base):
     __tablename__ = "subscriptions"
     id = Column(Integer, primary_key=True, autoincrement=True)
-    channel_id = Column(BigInteger, ForeignKey("channels.id"), nullable=False)
+    channel_id = Column(
+        BigInteger,
+        ForeignKey("channels.id"),
+        nullable=False,
+        index=True,
+        comment="frequent lookup",
+    )
     type = Column(String, nullable=False)
     target_id = Column(String, nullable=False)
     target_kind = Column(String, nullable=False)
@@ -64,8 +70,14 @@ class Cursor(Base):
 class RelayLog(Base):
     __tablename__ = "relay_log"
     id = Column(Integer, primary_key=True, autoincrement=True)
-    subscription_id = Column(Integer, ForeignKey("subscriptions.id"), nullable=False)
-    item_id = Column(String, nullable=False)
+    subscription_id = Column(
+        Integer,
+        ForeignKey("subscriptions.id"),
+        nullable=False,
+        index=True,
+        comment="frequent lookup",
+    )
+    item_id = Column(String, nullable=False, index=True, comment="frequent lookup")
     item_hash = Column(String, nullable=True)
     relayed_at = Column(DateTime, server_default=func.now(), nullable=False)
 


### PR DESCRIPTION
## Summary
- index frequent lookup fields in SQLAlchemy models
- add Alembic migration for lookup indexes
- remind contributors to run migrations after pulling

## Rationale and Context
Improve query performance on common lookups and document migration workflow.

## SemVer Justification
Patch: backwards-compatible performance and documentation updates.

## Test Evidence
- `make fmt` *(fails: unknown flag --rm)*
- `make check` *(fails: docker: 'compose' is not a docker command)*

## Risk Assessment and Rollback Plan
Low risk: new indexes and documentation. Roll back by reverting commits and downgrading migration.

## Affected Packages
- n/a

### Checklist
- [x] Intake analysis complete
- [ ] Plan reviewed and approved
- [ ] Version files updated
- [x] CHANGELOG.md updated
- [ ] CI pipeline passing
- [x] Documentation synchronized
- [ ] Security audit complete
- [ ] Release tags prepared

------
https://chatgpt.com/codex/tasks/task_e_68a08329869c8332997a78e1d7a141da