### PR TITLE
fix(config): require essential env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented here.
 
 ### Fixed
 - Validate adapter responses against JSON schemas and relay minimal links on mismatch.
+- Exit with clear error when required environment variables are missing.
 
 ## [1.3.14] - 2025-08-16
 ### Security

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -1,0 +1,17 @@
+import os
+import pytest
+from prometheus_client import REGISTRY
+
+os.environ.setdefault("DISCORD_TOKEN", "test-token")
+os.environ.setdefault("ADAPTER_AUTH_TOKEN", "test-adapter-token")
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch, tmp_path):
+    monkeypatch.setenv("DISCORD_TOKEN", os.environ["DISCORD_TOKEN"])
+    monkeypatch.setenv("ADAPTER_AUTH_TOKEN", os.environ["ADAPTER_AUTH_TOKEN"])
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path}/test.db")
+    yield
+    for collector in list(REGISTRY._collector_to_names):
+        REGISTRY.unregister(collector)

--- a/bot/tests/test_config.py
+++ b/bot/tests/test_config.py
@@ -1,5 +1,9 @@
+import importlib
 import pathlib
 import sys
+
+import pytest
+from prometheus_client import REGISTRY
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[2]))
 
@@ -25,3 +29,39 @@ def test_get_channel_config():
     }
     result = get_channel_config(cfg, 1, 10)
     assert result == {"a": 1, "b": 2, "c": 3}
+
+
+def _reload_main():
+    for collector in list(REGISTRY._collector_to_names):
+        REGISTRY.unregister(collector)
+    sys.modules.pop("bot.main", None)
+    return importlib.import_module("bot.main")
+
+
+def test_missing_discord_token(monkeypatch):
+    monkeypatch.delenv("DISCORD_TOKEN", raising=False)
+    monkeypatch.setenv("ADAPTER_AUTH_TOKEN", "x")
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
+    with pytest.raises(SystemExit) as exc:
+        _reload_main()
+    assert "DISCORD_TOKEN" in str(exc.value)
+
+
+def test_missing_adapter_auth_token(monkeypatch):
+    monkeypatch.setenv("DISCORD_TOKEN", "x")
+    monkeypatch.delenv("ADAPTER_AUTH_TOKEN", raising=False)
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
+    with pytest.raises(SystemExit) as exc:
+        _reload_main()
+    assert "ADAPTER_AUTH_TOKEN" in str(exc.value)
+
+
+def test_missing_database_settings(monkeypatch):
+    monkeypatch.setenv("DISCORD_TOKEN", "x")
+    monkeypatch.setenv("ADAPTER_AUTH_TOKEN", "x")
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.delenv("DB_HOST", raising=False)
+    monkeypatch.delenv("DB_NAME", raising=False)
+    with pytest.raises(SystemExit) as exc:
+        _reload_main()
+    assert "database settings" in str(exc.value)


### PR DESCRIPTION
## Summary
- fail fast if core environment variables are unset
- test missing configuration variables

## Rationale and Context
Ensures the bot exits with a clear error when required credentials or database settings are absent.

## SemVer Impact
Patch

## Test Evidence
- `black bot/main.py bot/tests/test_config.py bot/tests/conftest.py`
- `flake8 bot/main.py bot/tests/test_config.py bot/tests/conftest.py`
- `mypy bot/main.py bot/tests/test_config.py bot/tests/conftest.py`
- `pytest bot/tests/test_config.py`
- `pytest bot/tests/test_main.py`
- ⚠️ `make fmt` (missing docker compose)
- ⚠️ `make check` (missing docker compose)

## Risk and Rollback
Low risk. Revert commit to disable the new startup validation if issues arise.

## Affected Packages
- bot

------
https://chatgpt.com/codex/tasks/task_e_68a0847739208332b2ef02f65334d12d