### PR TITLE
fix(bot): defer env checks to main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ All notable changes to this project will be documented here.
 ### Fixed
 - Validate adapter responses against JSON schemas and relay minimal links on mismatch.
 - Exit with clear error when required environment variables are missing.
+- Allow importing `bot.main` without triggering environment checks by moving
+  initialization into `main()`.
 
 ## [1.3.14] - 2025-08-16
 ### Security

--- a/bot/tests/conftest.py
+++ b/bot/tests/conftest.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 from prometheus_client import REGISTRY
+from bot import main
 
 os.environ.setdefault("DISCORD_TOKEN", "test-token")
 os.environ.setdefault("ADAPTER_AUTH_TOKEN", "test-adapter-token")
@@ -12,6 +13,7 @@ def _env(monkeypatch, tmp_path):
     monkeypatch.setenv("DISCORD_TOKEN", os.environ["DISCORD_TOKEN"])
     monkeypatch.setenv("ADAPTER_AUTH_TOKEN", os.environ["ADAPTER_AUTH_TOKEN"])
     monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path}/test.db")
+    main.main(require_env=False)
     yield
     for collector in list(REGISTRY._collector_to_names):
         REGISTRY.unregister(collector)

--- a/bot/tests/test_main.py
+++ b/bot/tests/test_main.py
@@ -11,5 +11,6 @@ def test_flbot_without_telegram(monkeypatch):
         REGISTRY.unregister(collector)
     sys.modules.pop("bot.main", None)
     m = importlib.import_module("bot.main")
+    m.main(require_env=False)
     bot = m.FLBot()
     assert bot.bridge is None

--- a/bot/tests/test_subscription_persistence.py
+++ b/bot/tests/test_subscription_persistence.py
@@ -16,7 +16,9 @@ def _reload_main():
     for collector in list(REGISTRY._collector_to_names):
         REGISTRY.unregister(collector)
     sys.modules.pop("bot.main", None)
-    return importlib.import_module("bot.main")
+    m = importlib.import_module("bot.main")
+    m.main(require_env=False)
+    return m
 
 
 def test_subscriptions_persist_across_restarts(tmp_path, monkeypatch):
@@ -24,6 +26,8 @@ def test_subscriptions_persist_across_restarts(tmp_path, monkeypatch):
     db_url = f"sqlite:///{db_file}"
     monkeypatch.setenv("DATABASE_URL", db_url)
     monkeypatch.setenv("DISCORD_TOKEN", "x")
+    monkeypatch.delenv("TELEGRAM_API_ID", raising=False)
+    monkeypatch.delenv("TELEGRAM_API_HASH", raising=False)
 
     db = storage.init_db(db_url)
     sub_id = storage.add_subscription(db, 1, "events", "cities/1")


### PR DESCRIPTION
## Summary
- move environment variable checks into `main()` and expose entry point
- call `main()` from tests to initialize globals

## Rationale and Context
- importing `bot.main` previously executed environment checks and raised `SystemExit`, making tests brittle

## SemVer Justification
- fix: internal behavior change without breaking API

## Test Evidence
- `PYTHONPATH=. pytest` (59 passed, 3 skipped)

------
https://chatgpt.com/codex/tasks/task_e_68a194be3788833293390dc8cd17374c