### PR TITLE
chore(build): adopt docker compose CLI (patch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented here.
 ### Changed
 - Install Python dependencies from `requirements.lock` for reproducible builds.
 - Share an aiohttp `ClientSession` with a default timeout across adapter requests and close it on shutdown.
+- Replace `docker-compose` commands with `docker compose` and document the Docker Compose V2 plugin requirement.
 
 ### Security
 - Run `pip-audit` and `composer audit` in `make check` and release-hygiene workflow.

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,17 @@
 .PHONY: check fmt health
 
 fmt:
-	docker-compose run --rm bot sh -c "pip install -r requirements-dev.txt && black bot"
+	docker compose run --rm bot sh -c "pip install -r requirements-dev.txt && black bot"
 
 check:
-	docker-compose build
-	docker-compose run --rm bot sh -c "pip install -r requirements-dev.txt && pip-audit && black --check bot && flake8 bot && mypy bot && pytest"
-	docker-compose -f tests/docker-compose.test.yml build
-	docker-compose -f tests/docker-compose.test.yml run --rm -e MOCK_ADAPTER=1 bot-test
-	docker-compose -f tests/docker-compose.test.yml down || true
+	docker compose build
+	docker compose run --rm bot sh -c "pip install -r requirements-dev.txt && pip-audit && black --check bot && flake8 bot && mypy bot && pytest"
+	docker compose -f tests/docker-compose.test.yml build
+	docker compose -f tests/docker-compose.test.yml run --rm -e MOCK_ADAPTER=1 bot-test
+	docker compose -f tests/docker-compose.test.yml down || true
 	docker run --rm -v $(PWD):/app composer audit
-	docker-compose run --rm adapter vendor/bin/phpunit
+	docker compose run --rm adapter vendor/bin/phpunit
 
 health:
-	docker-compose exec bot curl -f http://localhost:8000/ready
-	docker-compose exec adapter curl -f http://localhost:8000/healthz
+	docker compose exec bot curl -f http://localhost:8000/ready
+	docker compose exec adapter curl -f http://localhost:8000/healthz

--- a/README.markdown
+++ b/README.markdown
@@ -8,6 +8,8 @@ The `bot/` directory contains a Python application using `discord.py` that relay
 
 ### Docker Compose Quick Start
 
+> **Note**: The commands below use the Docker Compose V2 plugin (`docker compose`). Install the plugin if your Docker setup still relies on the legacy `docker-compose` binary.
+
 1. `bash scripts/install.sh` and select **Install**. This creates `.venv` and installs runtime and development dependencies.
 2. `docker compose up -d` to launch the adapter, bot, and database. The `db` service pins
    `postgres:15` to digest `sha256:0de3e43bbb424d5fb7ca1889150f8e1b525d6c9fbaf9df6d853dcbc2ed5ffa1e` for reproducible builds.

--- a/plan.md
+++ b/plan.md
@@ -1,24 +1,24 @@
 ## Goal
-Introduce a shared aiohttp ClientSession with a default timeout and ensure it is closed on shutdown.
+Replace deprecated `docker-compose` commands with the modern `docker compose` CLI and document the change.
 
 ## Constraints
 - Follow AGENTS.md: run `make fmt` and `make check` before committing.
-- Update tests, CHANGELOG.md, and documentation if needed.
+- Update README and CHANGELOG.md to reference the new CLI.
 
 ## Risks
-- Unclosed sessions could leak resources.
-- Improper refactor may break adapter_client callers.
+- Environments without the Docker Compose plugin will fail to run Makefile targets.
+- Command flag differences could break developer workflows.
 
 ## Test Plan
 - `make fmt`
 - `make check`
 
 ## Semver
-Patch release: internal refactor.
+Patch release: docs and tooling update.
 
 ## Affected Packages
-- Python bot code
-- Tests
+- Makefile
+- Documentation
 
 ## Rollback
-Revert the commit to restore per-call ClientSessions.
+Revert the commit to restore previous Compose commands.


### PR DESCRIPTION
## Summary
- switch Makefile targets from `docker-compose` to `docker compose`
- document Docker Compose V2 plugin requirement in README
- note CLI change in changelog

## Rationale and Context
Modern Docker installations favor the Compose V2 plugin (`docker compose`). This change aligns build tooling and docs with the current CLI while clarifying the requirement for developers.

## SemVer Justification
Patch: build and documentation updates only.

## Test Evidence
- `make fmt` *(fails: unknown flag --rm – Docker Compose plugin missing)*
- `make check` *(fails: docker: 'compose' is not a docker command)*

## Risk Assessment and Rollback Plan
- **Risk**: Developers without the Compose plugin cannot run Makefile targets.
- **Mitigation**: README points to plugin usage; rollback via `git revert <commit>` if needed.

## Affected Packages
- N/A


------
https://chatgpt.com/codex/tasks/task_e_68a19d05ca348332acf069160fcf594c