### PR TITLE
feat(bot): add guild role management commands (minor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented here.
 - Document running the adapter behind an HTTPS reverse proxy and note TLS expectations.
 - Index frequent lookup columns for faster database queries.
 - Docker-based tests for group posts, messages, and Telegram bridge flows.
+- Guild role management commands `/role add`, `/role remove`, and `/role list`.
 
 ### Changed
 - Install Python dependencies from `requirements.lock` for reproducible builds.

--- a/README.markdown
+++ b/README.markdown
@@ -79,6 +79,10 @@ Docker Compose declares health checks for both services using these endpoints. A
 
    The Telegram bridge automatically reconnects and forwards photos and documents as Discord attachments. For `messages` subscriptions, relayed DMs are also sent to the mapped Telegram chat.
 
+### Role Management
+
+Use `/role add <user> <role_id>` to assign roles, `/role remove <user> <role_id>` to revoke them, and `/role list` to display available roles. These commands require the **Manage Roles** permission.
+
 Run the bot with:
 
 ```bash

--- a/bot/tests/test_role_commands.py
+++ b/bot/tests/test_role_commands.py
@@ -1,0 +1,70 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from bot import main
+
+
+def make_interaction(*, has_perms: bool = True, role_exists: bool = True):
+    interaction = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+    guild = SimpleNamespace(
+        get_role=(lambda _id: SimpleNamespace(id=_id) if role_exists else None),
+        roles=[SimpleNamespace(id=1, name="role")] if role_exists else [],
+    )
+    interaction.guild = guild
+    interaction.user.guild_permissions = SimpleNamespace(manage_roles=has_perms)
+    return interaction
+
+
+def assert_ephemeral(interaction):
+    interaction.response.send_message.assert_called_once()
+    assert interaction.response.send_message.await_args.kwargs.get("ephemeral") is True
+
+
+def test_role_add_success():
+    interaction = make_interaction()
+    member = SimpleNamespace(add_roles=AsyncMock())
+    with (
+        patch("bot.main.bot_bucket.acquire", AsyncMock()),
+        patch("bot.main.bot_tokens.set"),
+    ):
+        asyncio.run(main.role_add.callback(interaction, member, 1))
+    member.add_roles.assert_awaited_once()
+    interaction.response.send_message.assert_called_once_with("Role added")
+
+
+def test_role_remove_success():
+    interaction = make_interaction()
+    member = SimpleNamespace(remove_roles=AsyncMock())
+    with (
+        patch("bot.main.bot_bucket.acquire", AsyncMock()),
+        patch("bot.main.bot_tokens.set"),
+    ):
+        asyncio.run(main.role_remove.callback(interaction, member, 1))
+    member.remove_roles.assert_awaited_once()
+    interaction.response.send_message.assert_called_once_with("Role removed")
+
+
+def test_role_permission_error():
+    interaction = make_interaction(has_perms=False)
+    member = SimpleNamespace(add_roles=AsyncMock())
+    with (
+        patch("bot.main.bot_bucket.acquire", AsyncMock()),
+        patch("bot.main.bot_tokens.set"),
+    ):
+        asyncio.run(main.role_add.callback(interaction, member, 1))
+    member.add_roles.assert_not_called()
+    assert_ephemeral(interaction)
+
+
+def test_role_invalid_role():
+    interaction = make_interaction(role_exists=False)
+    member = SimpleNamespace(add_roles=AsyncMock())
+    with (
+        patch("bot.main.bot_bucket.acquire", AsyncMock()),
+        patch("bot.main.bot_tokens.set"),
+    ):
+        asyncio.run(main.role_add.callback(interaction, member, 99))
+    member.add_roles.assert_not_called()
+    assert_ephemeral(interaction)


### PR DESCRIPTION
## Summary
- add `/role` group with add, remove, and list commands for guild roles
- document new role management commands
- test role command success, permission errors, and invalid roles

## Rationale and Context
Enables administrators to manage member roles directly from the bot, improving guild moderation features.

## SemVer Justification
- **MINOR**: Adds new functionality in a backward-compatible manner.

## Test Evidence
- `make fmt` *(fails: `/bin/sh: 1: docker-compose: not found`)*
- `make check` *(fails: `docker-compose: No such file or directory`)*
- `PYTHONPATH=. pytest bot/tests/test_role_commands.py`

## Risk Assessment and Rollback Plan
- Low risk: commands isolated to new group.
- Rollback by reverting commits `da51b04`, `e43488a`, `3070950`, and `5e09e7b`.

## Affected Packages
- bot


------
https://chatgpt.com/codex/tasks/task_e_68a1a17bfc0c83329ab07b32148f71f1