### PR TITLE
feat(bot): add channel management commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented here.
 - Index frequent lookup columns for faster database queries.
 - Docker-based tests for group posts, messages, and Telegram bridge flows.
 - Guild role management commands `/role add`, `/role remove`, and `/role list`.
+- Channel management commands `/channel create`, `/channel delete`, and `/channel rename` with permission checks.
 
 ### Changed
 - Install Python dependencies from `requirements.lock` for reproducible builds.

--- a/README.markdown
+++ b/README.markdown
@@ -79,6 +79,10 @@ Docker Compose declares health checks for both services using these endpoints. A
 
    The Telegram bridge automatically reconnects and forwards photos and documents as Discord attachments. For `messages` subscriptions, relayed DMs are also sent to the mapped Telegram chat.
 
+### Channel Management
+
+Use `/channel create <name>` to create text channels, `/channel delete <channel>` to remove them, and `/channel rename <channel> <name>` to rename an existing channel. These commands require the **Manage Channels** permission.
+
 ### Role Management
 
 Use `/role add <user> <role_id>` to assign roles, `/role remove <user> <role_id>` to revoke them, and `/role list` to display available roles. These commands require the **Manage Roles** permission.

--- a/bot/tests/test_channel_commands.py
+++ b/bot/tests/test_channel_commands.py
@@ -1,0 +1,65 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+from bot import main
+
+
+def make_interaction(*, has_perms: bool = True):
+    interaction = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+    guild = SimpleNamespace(create_text_channel=AsyncMock())
+    interaction.guild = guild
+    interaction.user.guild_permissions = SimpleNamespace(manage_channels=has_perms)
+    return interaction
+
+
+def assert_ephemeral(interaction):
+    interaction.response.send_message.assert_called_once()
+    assert interaction.response.send_message.await_args.kwargs.get("ephemeral") is True
+
+
+def test_channel_create_success():
+    interaction = make_interaction()
+    with (
+        patch("bot.main.bot_bucket.acquire", AsyncMock()),
+        patch("bot.main.bot_tokens.set"),
+    ):
+        asyncio.run(main.channel_create.callback(interaction, "new"))
+    interaction.guild.create_text_channel.assert_awaited_once_with("new")
+    interaction.response.send_message.assert_called_once_with("Channel created")
+
+
+def test_channel_delete_success():
+    interaction = make_interaction()
+    channel = SimpleNamespace(delete=AsyncMock())
+    with (
+        patch("bot.main.bot_bucket.acquire", AsyncMock()),
+        patch("bot.main.bot_tokens.set"),
+    ):
+        asyncio.run(main.channel_delete.callback(interaction, channel))
+    channel.delete.assert_awaited_once()
+    interaction.response.send_message.assert_called_once_with("Channel deleted")
+
+
+def test_channel_rename_success():
+    interaction = make_interaction()
+    channel = SimpleNamespace(edit=AsyncMock())
+    with (
+        patch("bot.main.bot_bucket.acquire", AsyncMock()),
+        patch("bot.main.bot_tokens.set"),
+    ):
+        asyncio.run(main.channel_rename.callback(interaction, channel, "renamed"))
+    channel.edit.assert_awaited_once_with(name="renamed")
+    interaction.response.send_message.assert_called_once_with("Channel renamed")
+
+
+def test_channel_create_permission_error():
+    interaction = make_interaction(has_perms=False)
+    with (
+        patch("bot.main.bot_bucket.acquire", AsyncMock()),
+        patch("bot.main.bot_tokens.set"),
+    ):
+        asyncio.run(main.channel_create.callback(interaction, "new"))
+    interaction.guild.create_text_channel.assert_not_called()
+    assert_ephemeral(interaction)


### PR DESCRIPTION
## Summary
- add `/channel create`, `/channel delete`, and `/channel rename` commands with permission checks
- document channel management in README and CHANGELOG
- cover new commands with unit tests

## Rationale and context
Adds channel management capabilities to the bot so administrators can create, delete, or rename channels directly via slash commands.

## SemVer justification
feat: user-facing commands introduce new capabilities and warrant a MINOR version bump.

## Test evidence
- `make fmt` *(fails: docker-compose: not found)*
- `black bot/main.py bot/tests/test_channel_commands.py`
- `make check` *(fails: docker-compose: not found)*
- `PYTHONPATH=. pytest bot/tests/test_channel_commands.py`
- `flake8 bot/main.py bot/tests/test_channel_commands.py`
- `mypy bot/main.py bot/tests/test_channel_commands.py` *(fails: missing stubs and union-attr errors)*

## Risk assessment and rollback plan
Adds isolated commands guarded by Discord permissions; rollback via `git revert 99a5798` if issues arise.

## Affected packages
- `bot`


------
https://chatgpt.com/codex/tasks/task_e_68a1a3aee9308332921c8b79a9cd3e90