### PR TITLE
ci(health): add unified health check script (1.18.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+## [1.18.2] - 2025-08-19
+
+### CI
+- ci: add unified health-check script for bot and adapter endpoints.
+
 ## [1.18.1] - 2025-08-19
 
 ### Docs

--- a/Makefile
+++ b/Makefile
@@ -13,5 +13,4 @@ check:
 	docker-compose run --rm adapter vendor/bin/phpunit
 
 health:
-	docker-compose exec bot curl -f http://localhost:8000/ready
-	docker-compose exec adapter curl -f http://localhost:8000/healthz
+	./scripts/health-check.sh --confirm

--- a/README.markdown
+++ b/README.markdown
@@ -172,7 +172,7 @@ future features. Use `/fl purge` to clear cached data when needed.
 
 ### Health Checks
 
-Docker Compose declares health checks for both services using these endpoints. After the stack is running, `make health` executes them manually.
+Docker Compose declares health checks for both services using these endpoints. After the stack is running, `scripts/health-check.sh --confirm` or `make health` runs them manually.
 
 - Adapter: `GET http://localhost:8000/healthz` for liveness and `GET http://localhost:8000/metrics` for Prometheus metrics.
 - Bot: `GET http://localhost:8000/ready` for readiness and `GET http://localhost:8000/metrics` for Prometheus metrics.

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "FetLife adapter library",
     "type": "library",
     "license": "AGPL-3.0-or-later",
-    "version": "1.18.1",
+    "version": "1.18.2",
     "require": {"php": "^8.2"},
     "require-dev": {"phpunit/phpunit": "9.6.23"},
     "autoload": {"psr-4": {"FetLife\\": "src/"}},

--- a/plan.md
+++ b/plan.md
@@ -1,5 +1,5 @@
 ## Goal
-Replace inline HTML management pages with Jinja2 templates and verify rendering.
+Introduce a reusable health-check script to verify bot and adapter endpoints and wire Makefile target to use it.
 
 ## Constraints
 - Follow AGENTS.md: run `docker-compose -f tests/docker-compose.test.yml run --rm -e MOCK_ADAPTER=1 bot-test`, `docker-compose build`, and `docker-compose run --rm bot sh -c "pip install -r requirements-dev.txt && black --check bot && flake8 bot && mypy bot"` before committing.
@@ -7,31 +7,30 @@ Replace inline HTML management pages with Jinja2 templates and verify rendering.
 - Validate with `su nobody -s /bin/bash -c ./codex.sh fast-validate`.
 
 ## Risks
-- Template paths misconfigured leading to runtime errors.
-- Tests may rely on previous inline HTML structure.
-- Unescaped input could allow HTML injection.
+- Script may fail when containers aren't running.
+- Root detection might block legitimate usage.
 
 ## Test Plan
-- `docker-compose -f tests/docker-compose.test.yml run --rm -e MOCK_ADAPTER=1 bot-test`
+- `./scripts/health-check.sh`
 - `docker-compose build`
 - `docker-compose run --rm bot sh -c "pip install -r requirements-dev.txt && black --check bot && flake8 bot && mypy bot"`
+- `docker-compose -f tests/docker-compose.test.yml run --rm -e MOCK_ADAPTER=1 bot-test`
+- `docker-compose -f tests/docker-compose.test.yml down || true`
+- `docker run --rm -v $(PWD):/app composer audit`
 - `pip-audit`
-- `composer audit`
 - `su nobody -s /bin/bash -c ./codex.sh fast-validate`
 
 ## Semver
-Minor release: add Jinja2-templated management web interface.
+Patch release: CI helper script.
 
 ## Affected Files
-- `bot/main.py`
-- `bot/templates/*`
-- `bot/tests/test_web_interface.py`
-- `requirements.txt`
-- `requirements.lock`
+- `scripts/health-check.sh`
+- `Makefile`
 - `README.markdown`
 - `CHANGELOG.md`
 - `pyproject.toml`
 - `composer.json`
+- `toaster.md`
 - `plan.md`
 
 ## Rollback

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fetlife-discord-bot"
-version = "1.18.1"
+version = "1.18.2"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 classifiers = [

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ${EUID:-$(id -u)} -eq 0 ]]; then
+  echo "Refusing to run health check as root" >&2
+  exit 1
+fi
+
+confirm=false
+if [[ "${1:-}" == "--confirm" ]]; then
+  confirm=true
+  shift
+fi
+
+dry_run=true
+$confirm && dry_run=false
+
+run() {
+  if $dry_run; then
+    echo "[dry-run] $*"
+  else
+    "$@"
+  fi
+}
+
+run docker-compose exec bot curl -fsS -o /dev/null http://localhost:8000/ready
+run docker-compose exec bot curl -fsS -o /dev/null http://localhost:8000/metrics
+run docker-compose exec adapter curl -fsS -o /dev/null http://localhost:8000/healthz
+run docker-compose exec adapter curl -fsS -o /dev/null http://localhost:8000/metrics
+
+echo "health checks passed"

--- a/toaster.md
+++ b/toaster.md
@@ -1,8 +1,8 @@
-# toaster.md — Fetlife-Discord-Bot (v1.18.1)
+# toaster.md — Fetlife-Discord-Bot (v1.18.2)
 
 **TL;DR:** Discord bot and PHP adapter that relay FetLife activity into chat channels.  
 **Primary runtime(s):** Python 3.11 & PHP 8.2 · **Targets:** bot, adapter services · **Owner(s):** @c1nderscript @raincoats  
-**Last refreshed:** 2025-08-19 12:28 UTC
+**Last refreshed:** 2025-08-19 10:08 UTC
 
 ## System Overview
 Python bot polls a FetLife adapter service, persists state in PostgreSQL, and forwards updates to Discord and optional Telegram chats.


### PR DESCRIPTION
## Summary
- add scripts/health-check.sh for bot and adapter readiness/metrics probes
- wire Makefile `health` target to the new script
- bump version to 1.18.2

## Rationale
Provide a single entry point for health verification so CI and developers run identical checks.

## SemVer
Patch – tooling-only change.

## Test Evidence
- `su nobody -s /bin/bash -c ./scripts/health-check.sh` *(dry run)*
- `docker-compose build` *(command not found)*
- `docker-compose run --rm bot sh -c "pip install -r requirements-dev.txt && black --check bot && flake8 bot && mypy bot"` *(command not found)*
- `docker-compose -f tests/docker-compose.test.yml run --rm -e MOCK_ADAPTER=1 bot-test` *(command not found)*
- `docker run --rm -v $PWD:/app composer audit` *(command not found)*
- `pip-audit` *(command not found)*
- `su nobody -s /bin/bash -c ./codex.sh fast-validate`

## Risk
Low – script only curls internal endpoints; failures surface during execution.

## Affected Packages
- Python
- PHP

## Checklist
- [ ] Analysis complete
- [ ] Docs synced
- [ ] CI green
- [ ] Security audit
- [ ] Tags prepared
- [ ] codex.sh validated

------
https://chatgpt.com/codex/tasks/task_e_68a44c69ea448332b5b2e1583d249cd8