### PR TITLE
ci(workflows): add deploy validation and health gating (1.18.4)

### DIFF
--- a/.github/workflows/deploy-validation.yml
+++ b/.github/workflows/deploy-validation.yml
@@ -1,0 +1,17 @@
+name: deploy-validation
+on:
+  push:
+    branches: [main]
+  workflow_call:
+  workflow_dispatch:
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Run health check
+        run: ./scripts/health-check.sh
+      - name: Run deployment validation
+        run: ./scripts/deploy-validate.sh

--- a/.github/workflows/release-hygiene.yml
+++ b/.github/workflows/release-hygiene.yml
@@ -11,6 +11,8 @@ jobs:
           fetch-depth: 0
       - name: make check
         run: make check
+      - name: make health
+        run: make health
       - name: pip-audit
         run: |
           python -m pip install --upgrade pip pip-audit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@ All notable changes to this project will be documented here.
 
 ## [Unreleased]
 
+## [1.18.4] - 2025-08-19
+### CI
+- ci: add deploy validation workflow and gate pull requests on make health.
+
 ## [1.18.3] - 2025-08-19
 ### CI
 - ci: add deployment validation script to verify env vars, database connection, and TLS cert.

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "FetLife adapter library",
     "type": "library",
     "license": "AGPL-3.0-or-later",
-    "version": "1.18.3",
+    "version": "1.18.4",
     "require": {"php": "^8.2"},
     "require-dev": {"phpunit/phpunit": "9.6.23"},
     "autoload": {"psr-4": {"FetLife\\": "src/"}},

--- a/plan.md
+++ b/plan.md
@@ -1,5 +1,5 @@
 ## Goal
-Add deployment validation script to ensure required env vars are set, database connectivity works, and a TLS certificate exists.
+Add deployment validation workflow and gate pull requests on make health.
 
 ## Constraints
 - Follow AGENTS.md: run `docker-compose -f tests/docker-compose.test.yml run --rm -e MOCK_ADAPTER=1 bot-test`, `docker-compose build`, and `docker-compose run --rm bot sh -c "pip install -r requirements-dev.txt && black --check bot && flake8 bot && mypy bot"` before committing.
@@ -7,10 +7,12 @@ Add deployment validation script to ensure required env vars are set, database c
 - Validate with `su nobody -s /bin/bash -c ./codex.sh fast-validate`.
 
 ## Risks
-- Missing Postgres client or TLS certificate may cause false negatives.
+- Health scripts may fail due to missing services or env vars.
 
 ## Test Plan
-- `su nobody -s /bin/bash -c ./scripts/deploy-validate.sh`
+- `./scripts/health-check.sh`
+- `./scripts/deploy-validate.sh`
+- `make health`
 - `docker-compose build`
 - `docker-compose run --rm bot sh -c "pip install -r requirements-dev.txt && black --check bot && flake8 bot && mypy bot"`
 - `docker-compose -f tests/docker-compose.test.yml run --rm -e MOCK_ADAPTER=1 bot-test`
@@ -20,15 +22,15 @@ Add deployment validation script to ensure required env vars are set, database c
 - `su nobody -s /bin/bash -c ./codex.sh fast-validate`
 
 ## Semver
-Patch release: add deployment validation script.
+Patch release: CI workflow improvements.
 
 ## Affected Files
-- scripts/deploy-validate.sh
-- README.markdown
-- toaster.md
+- .github/workflows/deploy-validation.yml
+- .github/workflows/release-hygiene.yml
 - CHANGELOG.md
 - pyproject.toml
 - composer.json
+- toaster.md
 - plan.md
 
 ## Rollback

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fetlife-discord-bot"
-version = "1.18.3"
+version = "1.18.4"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 classifiers = [

--- a/toaster.md
+++ b/toaster.md
@@ -144,7 +144,7 @@ python -m bot.main
 ## Ops Notes
 
 * Docker/Compose images: `postgres:15`, local `bot` and `adapter` builds
-* CI workflows: `.github/workflows/release-hygiene.yml`, `.github/workflows/release.yml`
+* CI workflows: `.github/workflows/release-hygiene.yml`, `.github/workflows/release.yml`, `.github/workflows/deploy-validation.yml`
 * Metrics/Logs/Tracing: Prometheus metrics at `/metrics`
 
 ## Workflow Examples


### PR DESCRIPTION
## Summary
- run health and deployment validation scripts on pushes to main and before releases
- gate pull requests with `make health`
- bump version to 1.18.4

## Rationale
Ensures environments are healthy before release and enforces health checks during PRs.

## SemVer
Patch

## Test Evidence
- `su nobody -s /bin/bash -c ./scripts/health-check.sh`
- `su nobody -s /bin/bash -c ./scripts/deploy-validate.sh` *(fails: Missing required env vars)*
- `su nobody -s /bin/bash -c 'make health'` *(fails: docker-compose: command not found)*
- `docker-compose build` *(fails: command not found)*
- `docker-compose run --rm bot sh -c "pip install -r requirements-dev.txt && black --check bot && flake8 bot && mypy bot"` *(fails: command not found)*
- `docker-compose -f tests/docker-compose.test.yml run --rm -e MOCK_ADAPTER=1 bot-test` *(fails: command not found)*
- `docker run --rm -v $(pwd):/app composer audit` *(fails: command not found)*
- `composer audit --locked`
- `python -m pip_audit`
- `su nobody -s /bin/bash -c ./codex.sh fast-validate`

## Risks
- Health scripts rely on docker-compose and environment variables, which may be absent in some setups.

## Affected Packages
- N/A

## Checklist
- [x] Analysis complete
- [x] Docs synced
- [ ] CI green
- [x] Security audit
- [ ] Tags prepared
- [x] codex.sh validated

------
https://chatgpt.com/codex/tasks/task_e_68a4512d37a8833287d25a1f318b1d79