### PR TITLE
fix(deploy): enable health-based rolling updates (1.23.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 All notable changes to this project will be documented here.
 
-## [Unreleased]
+## [1.23.1] - 2025-08-20
+### Changed
+- fix: use health-aware dependencies and start-first rolling updates in Docker Compose.
 
 ## [1.23.0] - 2025-08-20
 ### Added

--- a/README.markdown
+++ b/README.markdown
@@ -21,6 +21,10 @@ Adapter requests use a circuit breaker. After repeated failures the breaker open
    `postgres:15` to digest `sha256:0de3e43bbb424d5fb7ca1889150f8e1b525d6c9fbaf9df6d853dcbc2ed5ffa1e` for reproducible builds.
 3. Generate an invite link from the [Discord Developer Portal](https://discord.com/developers/applications), invite the bot to your server, then run `/fl login` to verify adapter authentication, `/fl subscribe events location:cities/5898 min_attendees:10`, `/fl subscribe group_posts group:1`, `/fl subscribe messages inbox`, `/fl list`, and `/fl test <id>` in Discord.
 
+### Rolling Updates
+
+`docker-compose.yml` configures `depends_on` with `condition: service_healthy` and a `deploy.update_config` of `order: start-first` to enable rolling updates. During deployments, new containers start and pass health checks before old ones stop, reducing downtime.
+
 ### Environment Variables
 
 Copy `.env.example` to `.env` and fill in your values. The `.env` file supports these keys:

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "FetLife adapter library",
     "type": "library",
     "license": "AGPL-3.0-or-later",
-    "version": "1.23.0",
+    "version": "1.23.1",
     "require": {"php": "^8.2"},
     "require-dev": {"phpunit/phpunit": "9.6.23"},
     "autoload": {"psr-4": {"FetLife\\": "src/"}},

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,10 +20,15 @@ services:
     environment:
       ADAPTER_AUTH_TOKEN: ${ADAPTER_AUTH_TOKEN}
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     ports:
       - "8000:8000"
     restart: unless-stopped
+    deploy:
+      update_config:
+        order: start-first
+        monitor: 30s
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/healthz"]
       interval: 30s
@@ -41,10 +46,16 @@ services:
       ADAPTER_AUTH_TOKEN: ${ADAPTER_AUTH_TOKEN}
       ADAPTER_BASE_URL: ${ADAPTER_BASE_URL}
     depends_on:
-      - adapter
-      - db
+      adapter:
+        condition: service_healthy
+      db:
+        condition: service_healthy
     command: ["python3", "-m", "bot.main"]
     restart: unless-stopped
+    deploy:
+      update_config:
+        order: start-first
+        monitor: 30s
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/ready"]
       interval: 30s

--- a/plan.md
+++ b/plan.md
@@ -1,5 +1,5 @@
 ## Goal
-Introduce circuit breaker for adapter interactions with metrics and management UI.
+Align Docker Compose services with health-based dependencies and rolling update strategy.
 
 ## Constraints
 - Follow AGENTS.md: run `docker-compose -f tests/docker-compose.test.yml run --rm -e MOCK_ADAPTER=1 bot-test`, `docker-compose build`, and `docker-compose run --rm bot sh -c "pip install -r requirements-dev.txt && black --check bot && flake8 bot && mypy bot"` before committing.
@@ -19,16 +19,12 @@ Introduce circuit breaker for adapter interactions with metrics and management U
 - `su nobody -s /bin/bash -c ./codex.sh fast-validate`
 
 ## Semver
-Minor release: adds adapter circuit breaker with graceful degradation.
+Patch release: configuration and documentation improvements.
 
 ## Affected Files
-- bot/circuit_breaker.py
-- bot/main.py
-- bot/templates/index.html
-- bot/tests/test_circuit_breaker.py
-- CHANGELOG.md
+- docker-compose.yml
 - README.markdown
-- toaster.md
+- CHANGELOG.md
 - pyproject.toml
 - composer.json
 - plan.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fetlife-discord-bot"
-version = "1.23.0"
+version = "1.23.1"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 classifiers = [


### PR DESCRIPTION
## Summary
- ensure adapter and bot wait for healthy dependencies before starting
- configure start-first rolling updates for adapter and bot
- document health-aware rolling update behavior

## Rationale
Health checks gate service startup and rolling deployments reduce downtime.

## SemVer
Patch: backward compatible deployment and documentation changes.

## Test Evidence
- `docker-compose build` *(fails: command not found)*
- `docker-compose run --rm bot sh -c "pip install -r requirements-dev.txt && black --check bot && flake8 bot && mypy bot"` *(fails: command not found)*
- `docker-compose -f tests/docker-compose.test.yml run --rm -e MOCK_ADAPTER=1 bot-test` *(fails: command not found)*
- `docker-compose -f tests/docker-compose.test.yml down || true` *(fails: command not found)*
- `pip-audit` *(found 3 vulnerabilities in jinja2)*
- `docker run --rm -v $(pwd):/app composer audit` *(fails: command not found)*
- `su nobody -s /bin/bash -c "./codex.sh fast-validate"`

## Risk
Service health checks must succeed or updates will stall; start-first updates briefly double resource usage.

## Affected Packages
- fetlife-discord-bot
- project/fetlife-discord-bot (PHP adapter library)

## Checklist
- [x] Analysis complete
- [x] Docs synced
- [ ] CI green
- [x] Security audit
- [ ] Tags prepared
- [x] codex.sh validated

------
https://chatgpt.com/codex/tasks/task_e_68a5aa7151748332b5efe484915a370a