### PR TITLE
fix(adapter): propagate task cancellation (1.26.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 All notable changes to this project will be documented here.
 
+## [1.26.3] - 2025-08-21
+### Fixed
+- fix: propagate task cancellation in adapter_request
+### Tests
+- test: cover adapter_request cancellation
+
 ## [1.26.2] - 2025-08-20
 ### Fixed
 - fix: return `500` when `ADAPTER_AUTH_TOKEN` is missing

--- a/bot/main.py
+++ b/bot/main.py
@@ -189,6 +189,8 @@ async def adapter_request(fn, *args, fallback=None, **kwargs):
         adapter_breaker.record_success()
         breaker_state.set(0)
         return result, True
+    except asyncio.CancelledError:
+        raise
     except Exception:
         adapter_errors.inc()
         adapter_breaker.record_failure()

--- a/bot/tests/test_adapter_request.py
+++ b/bot/tests/test_adapter_request.py
@@ -1,0 +1,18 @@
+import asyncio
+import pytest
+
+from bot.main import adapter_request
+
+
+def test_adapter_request_propagates_cancellation():
+    async def slow_fn():
+        await asyncio.sleep(1)
+
+    async def run():
+        task = asyncio.create_task(adapter_request(slow_fn))
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(run())

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "FetLife adapter library",
     "type": "library",
     "license": "AGPL-3.0-or-later",
-    "version": "1.26.2",
+    "version": "1.26.3",
     "require": {"php": "^8.2"},
     "require-dev": {"phpunit/phpunit": "9.6.23"},
     "autoload": {"psr-4": {"FetLife\\": "src/"}},

--- a/plan.md
+++ b/plan.md
@@ -1,19 +1,18 @@
 ## Goal
-Enforce adapter authentication token requirement and document mandatory configuration.
+Ensure adapter_request propagates task cancellation by re-raising asyncio.CancelledError.
 
 ## Constraints
 - Follow AGENTS.md: run `docker-compose -f tests/docker-compose.test.yml run --rm -e MOCK_ADAPTER=1 bot-test`, `docker-compose build`, and `docker-compose run --rm bot sh -c "pip install -r requirements-dev.txt && black --check bot && flake8 bot && mypy bot"` before committing.
-- Run `pip-audit` and `docker run --rm -v $(pwd):/app composer audit`.
+- Run `pip-audit` and `composer audit`.
 - Validate with `su nobody -s /bin/bash -c ./codex.sh fast-validate`.
 
 ## Risks
-- Missing token may cause the adapter to reject all requests if misconfigured.
-- Tests may fail to capture HTTP status codes in CLI execution.
+- Missing cancellation may stall shutdown sequences.
+- Integration tests may fail to run in this environment.
 
 ## Test Plan
-- `vendor/bin/phpunit tests/MissingTokenTest.php`
 - `pip-audit`
-- `docker run --rm -v $(pwd):/app composer audit`
+- `composer audit`
 - `docker-compose -f tests/docker-compose.test.yml run --rm -e MOCK_ADAPTER=1 bot-test`
 - `docker-compose build`
 - `docker-compose run --rm bot sh -c "pip install -r requirements-dev.txt && black --check bot && flake8 bot && mypy bot"`
@@ -21,18 +20,15 @@ Enforce adapter authentication token requirement and document mandatory configur
 - `su nobody -s /bin/bash -c ./codex.sh fast-validate`
 
 ## Semver
-Patch release: backward-compatible security fix.
+Patch release: backward-compatible bug fix.
 
 ## Affected Files
-- adapter/public/index.php
-- tests/MissingTokenTest.php
-- README.markdown
-- docs/production.md
-- CHANGELOG.md
+- bot/main.py
+- bot/tests/test_adapter_request.py
 - pyproject.toml
 - composer.json
+- CHANGELOG.md
 - plan.md
-- toaster.md
 
 ## Rollback
 Revert commit.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fetlife-discord-bot"
-version = "1.26.2"
+version = "1.26.3"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 classifiers = [


### PR DESCRIPTION
## Summary
- re-raise `asyncio.CancelledError` in `adapter_request`
- add unit test for cancellation propagation
- bump version to 1.26.3

## Rationale
Ensures upstream task cancellation isn't swallowed by the adapter request helper.

## SemVer
Patch

## Test Evidence
- `black bot/main.py bot/tests/test_adapter_request.py`
- `flake8 bot`
- `mypy bot` *(fails: missing stubs and type errors)*
- `pip-audit` *(fails: jinja2 vulnerabilities)*
- `composer audit`
- `docker-compose -f tests/docker-compose.test.yml run --rm -e MOCK_ADAPTER=1 bot-test` *(fails: docker-compose not installed)*
- `docker-compose build` *(fails: docker-compose not installed)*
- `docker-compose run --rm bot sh -c "pip install -r requirements-dev.txt && black --check bot && flake8 bot && mypy bot"` *(fails: docker-compose not installed)*
- `docker-compose -f tests/docker-compose.test.yml down || true` *(fails: docker-compose not installed)*
- `su nobody -s /bin/bash -c ./codex.sh fast-validate`
- `PYTHONPATH=. pytest bot/tests/test_adapter_request.py -q`

## Risks
- Outstanding type-check and dependency audit issues
- Missing Docker prevents integration test coverage

## Affected Packages
- python, php

## Checklist
- [x] Analysis complete
- [x] Docs synced
- [ ] CI green
- [x] Security audit
- [ ] Tags prepared


------
https://chatgpt.com/codex/tasks/task_e_68a6befbaa108332a99bac627a0a0b2d