### PR TITLE
docs: document tests and templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 All notable changes to this project will be documented here.
 
+## [1.28.2] - 2025-08-22
+### Docs
+- docs: add AGENTS for bot tests and templates
+
 ## [1.28.1] - 2025-08-22
 ### Docs
 - docs: move libFetLife sections into docs/libfetlife.md and describe bot/adapter architecture in README

--- a/README.markdown
+++ b/README.markdown
@@ -1,4 +1,4 @@
-# FetLife Discord Bot - README (v1.28.1)
+# FetLife Discord Bot - README (v1.28.2)
 
 Python Discord bot paired with a PHP adapter to relay FetLife activity into chat channels. The bot polls the adapter, which wraps the legacy `libFetLife` scraper, and persists state in PostgreSQL. Documentation for `libFetLife` lives in [docs/libfetlife.md](docs/libfetlife.md).
 

--- a/bot/templates/AGENTS.md
+++ b/bot/templates/AGENTS.md
@@ -1,6 +1,10 @@
-# AGENTS: bot/templates/
+# AGENTS: bot/templates
+
+**Scope**: bot/templates
 
 **Purpose**: HTML templates for the management web interface.
+
+---
 
 ## File Context Map
 - `accounts.html`: manage FetLife accounts.
@@ -18,3 +22,9 @@
 - `timers.html`: schedule self-deleting messages.
 - `welcome.html`: configure welcome message and verification.
 - `welcome_preview.html`: render welcome message preview.
+
+## Rules
+- Rendered with Jinja2.
+- Reference static assets via `url_for('static', ...)`.
+- Avoid inline scripts and external network calls.
+- Ensure forms include CSRF tokens and accessible labels.

--- a/bot/tests/AGENTS.md
+++ b/bot/tests/AGENTS.md
@@ -1,9 +1,19 @@
 # AGENTS: bot/tests
 
+**Scope**: bot/tests
+
 **Purpose**: Pytest suite covering the Discord bot.
+
+---
 
 ## File Context Map
 - `conftest.py`: shared fixtures.
 - `fixtures/`: reusable test data.
 - `test_web_interface.py`: management web interface tests.
 - `test_*.py`: feature-specific tests for bot components.
+
+## Rules
+- Use `pytest` for all tests.
+- Mock external network calls or run through the adapter test harness.
+- Keep tests hermetic and idempotent.
+- Update or add tests when modifying bot behavior.

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "FetLife adapter library",
     "type": "library",
     "license": "AGPL-3.0-or-later",
-    "version": "1.28.1",
+    "version": "1.28.2",
     "require": {"php": "^8.2"},
     "require-dev": {"phpunit/phpunit": "9.6.23"},
     "autoload": {"psr-4": {"FetLife\\": "src/"}},

--- a/plan.md
+++ b/plan.md
@@ -1,5 +1,5 @@
 ## Goal
-Reorganize documentation by moving `libFetLife` sections into `docs/libfetlife.md`, rewrite the README opening to describe the bot/adapter architecture, and bump version to 1.28.1.
+Add detailed AGENTS.md files for `bot/tests` and `bot/templates` directories and bump version to 1.28.2.
 
 ## Constraints
 - Follow AGENTS.md instructions.
@@ -7,7 +7,7 @@ Reorganize documentation by moving `libFetLife` sections into `docs/libfetlife.m
 - Run CI commands before committing.
 
 ## Risks
-- Cross-file version mismatch could confuse releases.
+- Missing template rules could confuse contributors.
 - CI commands may fail due to missing dependencies.
 
 ## Test Plan
@@ -16,12 +16,12 @@ Reorganize documentation by moving `libFetLife` sections into `docs/libfetlife.m
 - `docker-compose run --rm bot sh -c "pip install -r requirements-dev.txt && black --check bot && flake8 bot && mypy bot"`
 
 ## Semver
-Patch release: documentation updates and refactor, bump version to 1.28.1.
+Patch release: documentation updates, bump version to 1.28.2.
 
 ## Affected Files
+- bot/tests/AGENTS.md
+- bot/templates/AGENTS.md
 - README.markdown
-- docs/libfetlife.md
-- docs/AGENTS.md
 - toaster.md
 - CHANGELOG.md
 - pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "fetlife-discord-bot"
-version = "1.28.1"
+version = "1.28.2"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
 classifiers = [

--- a/toaster.md
+++ b/toaster.md
@@ -1,4 +1,4 @@
-# toaster.md — Fetlife-Discord-Bot (v1.28.1)
+# toaster.md — Fetlife-Discord-Bot (v1.28.2)
 
 **TL;DR:** Discord bot and PHP adapter that relay FetLife activity into chat channels.  
 Each major directory now includes an `AGENTS.md` describing its purpose and key files.


### PR DESCRIPTION
## Summary
- add scope and rules for bot test suite
- document management templates and constraints
- bump version to 1.28.2

## Testing
- `docker-compose -f tests/docker-compose.test.yml run --rm -e MOCK_ADAPTER=1 bot-test` *(fails: build path or docker daemon missing)*
- `docker-compose build` *(fails: Couldn't find env file)*
- `docker-compose run --rm bot sh -c "pip install -r requirements-dev.txt && black --check bot && flake8 bot && mypy bot"` *(fails: Couldn't find env file)*

------
https://chatgpt.com/codex/tasks/task_e_68a83e328df883329170f6767aa3b1ac